### PR TITLE
Add rolling position sizers

### DIFF
--- a/src/portfolio_backtester/config.py
+++ b/src/portfolio_backtester/config.py
@@ -387,5 +387,9 @@ OPTIMIZER_PARAMETER_DEFAULTS = {
     "low": 4,
     "high": 18,
     "step": 2
-  }
+  },
+  "sizer_sharpe_window": {"type": "int", "low": 2, "high": 12, "step": 1},
+  "sizer_sortino_window": {"type": "int", "low": 2, "high": 12, "step": 1},
+  "sizer_beta_window": {"type": "int", "low": 2, "high": 12, "step": 1},
+  "sizer_corr_window": {"type": "int", "low": 2, "high": 12, "step": 1}
 }

--- a/src/portfolio_backtester/portfolio/position_sizer.py
+++ b/src/portfolio_backtester/portfolio/position_sizer.py
@@ -1,7 +1,96 @@
-
 import pandas as pd
+import numpy as np
+from typing import Callable, Dict
 
-def equal_weight_sizer(signals: pd.DataFrame) -> pd.DataFrame:
-    """Applies equal weighting to the signals."""
-    sized_signals = signals.div(signals.abs().sum(axis=1), axis=0)
-    return sized_signals
+
+def equal_weight_sizer(signals: pd.DataFrame, *_, **__) -> pd.DataFrame:
+    """Apply equal weighting to the signals."""
+    return signals.div(signals.abs().sum(axis=1), axis=0)
+
+
+def rolling_sharpe_sizer(
+    signals: pd.DataFrame,
+    prices: pd.DataFrame,
+    window: int,
+    **_,
+) -> pd.DataFrame:
+    rets = prices.pct_change(fill_method=None).fillna(0)
+    mean = rets.rolling(window).mean()
+    std = rets.rolling(window).std()
+    sharpe = mean / std.replace(0, np.nan)
+    sized = signals.mul(sharpe)
+    return sized.div(sized.abs().sum(axis=1), axis=0)
+
+
+def rolling_sortino_sizer(
+    signals: pd.DataFrame,
+    prices: pd.DataFrame,
+    window: int,
+    target_return: float = 0.0,
+    **_,
+) -> pd.DataFrame:
+    rets = prices.pct_change(fill_method=None).fillna(0)
+    mean = rets.rolling(window).mean() - target_return
+
+    def downside(series):
+        d = series[series < target_return]
+        if len(d) == 0:
+            return np.nan
+        return np.sqrt(np.mean((d - target_return) ** 2))
+
+    downside_dev = rets.rolling(window).apply(downside, raw=False)
+    sortino = mean / downside_dev.replace(0, np.nan)
+    sized = signals.mul(sortino)
+    return sized.div(sized.abs().sum(axis=1), axis=0)
+
+
+def rolling_beta_sizer(
+    signals: pd.DataFrame,
+    prices: pd.DataFrame,
+    benchmark: pd.Series,
+    window: int,
+    **_,
+) -> pd.DataFrame:
+    rets = prices.pct_change(fill_method=None).fillna(0)
+    bench_rets = benchmark.pct_change(fill_method=None).fillna(0)
+    beta = pd.DataFrame(index=rets.index, columns=rets.columns)
+    for col in rets.columns:
+        cov = rets[col].rolling(window).cov(bench_rets)
+        var = bench_rets.rolling(window).var()
+        beta[col] = cov / var
+    factor = 1 / beta.abs().replace(0, np.nan)
+    sized = signals.mul(factor)
+    return sized.div(sized.abs().sum(axis=1), axis=0)
+
+
+def rolling_benchmark_corr_sizer(
+    signals: pd.DataFrame,
+    prices: pd.DataFrame,
+    benchmark: pd.Series,
+    window: int,
+    **_,
+) -> pd.DataFrame:
+    rets = prices.pct_change(fill_method=None).fillna(0)
+    bench_rets = benchmark.pct_change(fill_method=None).fillna(0)
+    corr = pd.DataFrame(index=rets.index, columns=rets.columns)
+    for col in rets.columns:
+        corr[col] = rets[col].rolling(window).corr(bench_rets)
+    factor = 1 / (corr.abs() + 1e-9)
+    sized = signals.mul(factor)
+    return sized.div(sized.abs().sum(axis=1), axis=0)
+
+
+SIZER_REGISTRY: Dict[str, Callable] = {
+    "equal_weight": equal_weight_sizer,
+    "rolling_sharpe": rolling_sharpe_sizer,
+    "rolling_sortino": rolling_sortino_sizer,
+    "rolling_beta": rolling_beta_sizer,
+    "rolling_benchmark_corr": rolling_benchmark_corr_sizer,
+}
+
+
+def get_position_sizer(name: str) -> Callable:
+    try:
+        return SIZER_REGISTRY[name]
+    except KeyError as exc:
+        raise ValueError(f"Unknown position sizer: {name}") from exc

--- a/src/portfolio_backtester/strategies/base_strategy.py
+++ b/src/portfolio_backtester/strategies/base_strategy.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 
 from ..feature import Feature, BenchmarkSMA
-from ..portfolio.position_sizer import equal_weight_sizer
+from ..portfolio.position_sizer import get_position_sizer
 from ..signal_generators import BaseSignalGenerator
 
 
@@ -30,7 +30,8 @@ class BaseStrategy(ABC):
         return self.signal_generator_class(self.strategy_config)
 
     def get_position_sizer(self) -> Callable[[pd.DataFrame], pd.DataFrame]:
-        return equal_weight_sizer
+        name = self.strategy_config.get("position_sizer", "equal_weight")
+        return get_position_sizer(name)
 
     def get_volatility_target(self) -> float | None:
         return self.strategy_config.get("volatility_target")

--- a/tests/portfolio/test_position_sizer.py
+++ b/tests/portfolio/test_position_sizer.py
@@ -2,7 +2,15 @@
 import unittest
 import pandas as pd
 import numpy as np
-from src.portfolio_backtester.portfolio.position_sizer import equal_weight_sizer
+from scipy.stats import spearmanr
+
+from src.portfolio_backtester.portfolio.position_sizer import (
+    equal_weight_sizer,
+    rolling_sharpe_sizer,
+    rolling_sortino_sizer,
+    rolling_beta_sizer,
+    rolling_benchmark_corr_sizer,
+)
 
 class TestPositionSizer(unittest.TestCase):
 
@@ -38,6 +46,77 @@ class TestPositionSizer(unittest.TestCase):
         })
         result_weights = equal_weight_sizer(signals)
         pd.testing.assert_frame_equal(result_weights, expected_weights)
+
+    def _create_price_data(self):
+        dates = pd.date_range('2020-01-31', periods=5, freq='M')
+        prices = pd.DataFrame({
+            'A': [100, 110, 132, 145, 160],
+            'B': [100, 102, 104, 105, 107],
+            'C': [100, 98, 97, 97, 98]
+        }, index=dates)
+        benchmark = pd.Series([100, 101, 103, 105, 107], index=dates)
+        signals = pd.DataFrame(1, index=dates, columns=['A', 'B', 'C'])
+        return prices, benchmark, signals
+
+    def test_rolling_sharpe_sizer(self):
+        prices, bench, signals = self._create_price_data()
+        window = 2
+        rets = prices.pct_change(fill_method=None).fillna(0)
+        mean = rets.rolling(window).mean()
+        std = rets.rolling(window).std()
+        sharpe = mean / std.replace(0, np.nan)
+        expected = signals.mul(sharpe).div(signals.mul(sharpe).abs().sum(axis=1), axis=0)
+
+        result = rolling_sharpe_sizer(signals, prices, window)
+        pd.testing.assert_frame_equal(result, expected)
+
+    def test_rolling_sortino_sizer(self):
+        prices, bench, signals = self._create_price_data()
+        window = 2
+        target = 0.0
+        rets = prices.pct_change(fill_method=None).fillna(0)
+        mean = rets.rolling(window).mean() - target
+
+        def dd(series):
+            downside = series[series < target]
+            if len(downside) == 0:
+                return np.nan
+            return np.sqrt(np.mean((downside - target) ** 2))
+
+        downside = rets.rolling(window).apply(dd, raw=False)
+        sortino = mean / downside.replace(0, np.nan)
+        expected = signals.mul(sortino).div(signals.mul(sortino).abs().sum(axis=1), axis=0)
+
+        result = rolling_sortino_sizer(signals, prices, window, target_return=target)
+        pd.testing.assert_frame_equal(result, expected)
+
+    def test_rolling_beta_sizer(self):
+        prices, bench, signals = self._create_price_data()
+        window = 2
+        rets = prices.pct_change(fill_method=None).fillna(0)
+        bench_rets = bench.pct_change(fill_method=None).fillna(0)
+        beta = pd.DataFrame(index=rets.index, columns=rets.columns)
+        for col in rets.columns:
+            beta[col] = rets[col].rolling(window).cov(bench_rets) / bench_rets.rolling(window).var()
+        factor = 1 / beta.abs().replace(0, np.nan)
+        expected = signals.mul(factor).div(signals.mul(factor).abs().sum(axis=1), axis=0)
+
+        result = rolling_beta_sizer(signals, prices, bench, window)
+        pd.testing.assert_frame_equal(result, expected)
+
+    def test_rolling_benchmark_corr_sizer(self):
+        prices, bench, signals = self._create_price_data()
+        window = 2
+        rets = prices.pct_change(fill_method=None).fillna(0)
+        bench_rets = bench.pct_change(fill_method=None).fillna(0)
+        corr = pd.DataFrame(index=rets.index, columns=rets.columns)
+        for col in rets.columns:
+            corr[col] = rets[col].rolling(window).corr(bench_rets)
+        factor = 1 / (corr.abs() + 1e-9)
+        expected = signals.mul(factor).div(signals.mul(factor).abs().sum(axis=1), axis=0)
+
+        result = rolling_benchmark_corr_sizer(signals, prices, bench, window)
+        pd.testing.assert_frame_equal(result, expected)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- create reusable position sizer component
- add rolling Sharpe/Sortino/Beta/Benchmark correlation sizers
- make position sizer pluggable in Backtester and utilities
- expose sizer window parameters in config defaults
- expand unit tests to cover new position sizers

## Testing
- `pytest tests/portfolio/test_position_sizer.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686545cbb85c8333ab1402936a7d5d40