### PR TITLE
Add new rolling position sizers

### DIFF
--- a/src/portfolio_backtester/config.py
+++ b/src/portfolio_backtester/config.py
@@ -387,5 +387,9 @@ OPTIMIZER_PARAMETER_DEFAULTS = {
     "low": 4,
     "high": 18,
     "step": 2
-  }
+  },
+  "sharpe_sizer_window": {"type": "int", "low": 3, "high": 24, "step": 1},
+  "sortino_sizer_window": {"type": "int", "low": 3, "high": 24, "step": 1},
+  "beta_sizer_window": {"type": "int", "low": 3, "high": 24, "step": 1},
+  "corr_sizer_window": {"type": "int", "low": 3, "high": 24, "step": 1}
 }

--- a/src/portfolio_backtester/portfolio/position_sizer.py
+++ b/src/portfolio_backtester/portfolio/position_sizer.py
@@ -1,7 +1,96 @@
 
+import numpy as np
 import pandas as pd
+
 
 def equal_weight_sizer(signals: pd.DataFrame) -> pd.DataFrame:
     """Applies equal weighting to the signals."""
     sized_signals = signals.div(signals.abs().sum(axis=1), axis=0)
     return sized_signals
+
+
+def rolling_sharpe_sizer(
+    signals: pd.DataFrame,
+    returns: pd.DataFrame,
+    window: int,
+) -> pd.DataFrame:
+    """Size positions proportionally to rolling Sharpe ratio."""
+    rolling_mean = returns.rolling(window).mean()
+    rolling_std = returns.rolling(window).std().replace(0, np.nan)
+    sharpe = (rolling_mean / rolling_std).fillna(0)
+    sized = signals.mul(sharpe)
+    return sized.div(sized.abs().sum(axis=1), axis=0)
+
+
+def rolling_sortino_sizer(
+    signals: pd.DataFrame,
+    returns: pd.DataFrame,
+    window: int,
+    target_return: float = 0.0,
+) -> pd.DataFrame:
+    """Size positions proportionally to rolling Sortino ratio."""
+
+    def downside_dev(x: pd.Series) -> float:
+        downside = x[x < target_return] - target_return
+        if downside.empty:
+            return 0.0
+        return np.sqrt(np.mean(downside**2))
+
+    rolling_mean = returns.rolling(window).mean()
+    downside = returns.rolling(window).apply(downside_dev, raw=False)
+    downside = downside.replace(0, np.nan)
+    sortino = (rolling_mean / downside).fillna(0)
+    sized = signals.mul(sortino)
+    return sized.div(sized.abs().sum(axis=1), axis=0)
+
+
+def rolling_beta_sizer(
+    signals: pd.DataFrame,
+    returns: pd.DataFrame,
+    benchmark_returns: pd.Series,
+    window: int,
+) -> pd.DataFrame:
+    """Size positions inversely proportional to rolling beta versus benchmark."""
+
+    cov = returns.rolling(window).cov(benchmark_returns)
+    var = benchmark_returns.rolling(window).var()
+    beta = cov.div(var, axis=0).fillna(0)
+    factor = 1 / (1 + beta.abs())
+    sized = signals.mul(factor)
+    return sized.div(sized.abs().sum(axis=1), axis=0)
+
+
+def rolling_corr_sizer(
+    signals: pd.DataFrame,
+    returns: pd.DataFrame,
+    benchmark_returns: pd.Series,
+    window: int,
+) -> pd.DataFrame:
+    """Size positions inversely proportional to Spearman correlation with benchmark."""
+
+    ranks = returns.rank(axis=0, pct=True)
+    bench_rank = benchmark_returns.rank(pct=True)
+    corr = ranks.rolling(window).corr(bench_rank)
+    corr = corr.replace([np.inf, -np.inf], 0).fillna(0)
+    factor = (1 - corr.abs()).clip(lower=0)
+    sized = signals.mul(factor)
+    return sized.div(sized.abs().sum(axis=1), axis=0)
+
+
+POSITION_SIZER_REGISTRY = {
+    "equal_weight": equal_weight_sizer,
+    "rolling_sharpe": rolling_sharpe_sizer,
+    "rolling_sortino": rolling_sortino_sizer,
+    "rolling_beta": rolling_beta_sizer,
+    "rolling_corr": rolling_corr_sizer,
+}
+
+__all__ = [
+    "equal_weight_sizer",
+    "rolling_sharpe_sizer",
+    "rolling_sortino_sizer",
+    "rolling_beta_sizer",
+    "rolling_corr_sizer",
+    "POSITION_SIZER_REGISTRY",
+]
+

--- a/src/portfolio_backtester/utils.py
+++ b/src/portfolio_backtester/utils.py
@@ -31,7 +31,7 @@ def _run_scenario_static(
         Daily benchmark prices (needed by *calculate_metrics* in the caller).
     """
 
-    from .portfolio.position_sizer import equal_weight_sizer
+    from .portfolio.position_sizer import POSITION_SIZER_REGISTRY
     from .portfolio.rebalancing import rebalance
 
     strat_cls = _resolve_strategy(scenario_cfg["strategy"])
@@ -45,8 +45,34 @@ def _run_scenario_static(
         price_monthly[global_cfg["benchmark"]],
     )
 
+    sizer_name = scenario_cfg.get("position_sizer", "equal_weight")
+    sizer = POSITION_SIZER_REGISTRY.get(sizer_name)
+
+    rets_monthly = price_monthly[universe_cols].pct_change().fillna(0)
+    bench_rets_monthly = price_monthly[global_cfg["benchmark"]].pct_change().fillna(0)
+
+    if sizer_name == "equal_weight" or sizer is None:
+        if sizer is None and sizer_name != "none":
+            print(f"Unsupported position sizer: {sizer_name}. Using equal_weight.")
+        sized = POSITION_SIZER_REGISTRY["equal_weight"](signals)
+    elif sizer_name == "rolling_sharpe":
+        window = scenario_cfg["strategy_params"].get("sharpe_sizer_window", 6)
+        sized = sizer(signals, rets_monthly, window)
+    elif sizer_name == "rolling_sortino":
+        window = scenario_cfg["strategy_params"].get("sortino_sizer_window", 6)
+        target = scenario_cfg["strategy_params"].get("sizer_target_return", 0.0)
+        sized = sizer(signals, rets_monthly, window, target)
+    elif sizer_name == "rolling_beta":
+        window = scenario_cfg["strategy_params"].get("beta_sizer_window", 6)
+        sized = sizer(signals, rets_monthly, bench_rets_monthly, window)
+    elif sizer_name == "rolling_corr":
+        window = scenario_cfg["strategy_params"].get("corr_sizer_window", 6)
+        sized = sizer(signals, rets_monthly, bench_rets_monthly, window)
+    else:
+        sized = signals
+
     weights_monthly = rebalance(
-        equal_weight_sizer(signals), scenario_cfg["rebalance_frequency"]
+        sized, scenario_cfg["rebalance_frequency"]
     )
 
     # --- 2) Expand weights to daily frequency -------------------------------

--- a/tests/portfolio/test_position_sizer.py
+++ b/tests/portfolio/test_position_sizer.py
@@ -2,7 +2,13 @@
 import unittest
 import pandas as pd
 import numpy as np
-from src.portfolio_backtester.portfolio.position_sizer import equal_weight_sizer
+from src.portfolio_backtester.portfolio.position_sizer import (
+    equal_weight_sizer,
+    rolling_sharpe_sizer,
+    rolling_sortino_sizer,
+    rolling_beta_sizer,
+    rolling_corr_sizer,
+)
 
 class TestPositionSizer(unittest.TestCase):
 
@@ -20,6 +26,34 @@ class TestPositionSizer(unittest.TestCase):
         
         result_weights = equal_weight_sizer(signals)
         pd.testing.assert_frame_equal(result_weights, expected_weights)
+
+    def test_rolling_sharpe_sizer(self):
+        signals = pd.DataFrame({'A': [1, 1, 1], 'B': [1, 1, 1]})
+        returns = pd.DataFrame({'A': [0.1, 0.0, 0.1], 'B': [0.2, 0.2, 0.2]})
+        result = rolling_sharpe_sizer(signals, returns, window=2)
+        self.assertAlmostEqual(result.iloc[-1]['A'], 1.0)
+        self.assertAlmostEqual(result.iloc[-1]['B'], 0.0)
+
+    def test_rolling_sortino_sizer(self):
+        signals = pd.DataFrame({'A': [1, 1, 1], 'B': [1, 1, 1]})
+        returns = pd.DataFrame({'A': [0.1, -0.1, 0.2], 'B': [-0.1, -0.1, -0.1]})
+        result = rolling_sortino_sizer(signals, returns, window=2, target_return=0)
+        self.assertGreater(result.iloc[-1]['A'], result.iloc[-1]['B'])
+
+    def test_rolling_beta_sizer(self):
+        signals = pd.DataFrame({'A': [1, 1, 1], 'B': [1, 1, 1]})
+        returns = pd.DataFrame({'A': [0.1, 0.2, 0.3], 'B': [0.0, 0.0, 0.0]})
+        benchmark = pd.Series([0.1, 0.2, 0.3])
+        result = rolling_beta_sizer(signals, returns, benchmark, window=2)
+        self.assertGreater(result.iloc[-1]['B'], result.iloc[-1]['A'])
+
+    def test_rolling_corr_sizer(self):
+        signals = pd.DataFrame({'A': [1, 1, 1], 'B': [1, 1, 1]})
+        returns = pd.DataFrame({'A': [1, 2, 3], 'B': [1, 1, 1]})
+        benchmark = pd.Series([1, 2, 3])
+        result = rolling_corr_sizer(signals, returns, benchmark, window=2)
+        self.assertAlmostEqual(result.iloc[-1]['A'], 0.0)
+        self.assertAlmostEqual(result.iloc[-1]['B'], 1.0)
 
     def test_equal_weight_sizer_empty_signals(self):
         signals = pd.DataFrame()


### PR DESCRIPTION
## Summary
- implement rolling Sharpe, Sortino, beta and correlation position sizers
- expose new sizers through a registry
- plug the registry into `Backtester` and Optuna utils so scenario config selects the sizer
- add optimizer defaults for new sizer windows
- test all new sizing functions

## Testing
- `pytest tests/portfolio/test_position_sizer.py -q`
- `pytest -q` *(fails: ImportError: cannot import name '_lazywhere' from 'scipy._lib._util')*

------
https://chatgpt.com/codex/tasks/task_e_686545cbb85c8333ab1402936a7d5d40