### PR TITLE
Add beta-sized momentum variant and tunable long_only

### DIFF
--- a/src/portfolio_backtester/backtester.py
+++ b/src/portfolio_backtester/backtester.py
@@ -133,11 +133,18 @@ class Backtester:
 
         sizer_name = scenario_config.get("position_sizer", "equal_weight")
         sizer_func = get_position_sizer(sizer_name)
+        sizer_params = scenario_config.get("strategy_params", {}).copy()
+        for k in list(sizer_params.keys()):
+            if k.startswith("sizer_"):
+                parts = k.split("_", 2)
+                if len(parts) == 3:
+                    sizer_params[parts[2]] = sizer_params.pop(k)
+
         sized_signals = sizer_func(
             signals,
             strategy_data_monthly,
             benchmark_data_monthly,
-            **scenario_config.get("strategy_params", {}),
+            **sizer_params,
         )
         if verbose:
             logger.debug(f"Positions sized using {sizer_name}.")

--- a/src/portfolio_backtester/config.py
+++ b/src/portfolio_backtester/config.py
@@ -32,6 +32,31 @@ BACKTEST_SCENARIOS = [
         "mc_years": 10
     },
     {
+        "name": "Momentum_Beta_Sized",
+        "strategy": "momentum",
+        "rebalance_frequency": "ME",
+        "position_sizer": "rolling_beta",
+        "transaction_costs_bps": 10,
+        "train_window_months": 60,
+        "test_window_months": 24,
+        "optimize": [
+            {"parameter": "num_holdings", "metric": "Sortino", "min_value": 10, "max_value": 35, "step": 1},
+            {"parameter": "top_decile_fraction", "metric": "Sortino", "min_value": 0.05, "max_value": 0.3, "step": 0.01},
+            {"parameter": "lookback_months", "metric": "Sortino", "min_value": 3, "max_value": 14, "step": 1},
+            {"parameter": "smoothing_lambda", "metric": "Sortino", "min_value": 0.0, "max_value": 1.0, "step": 0.05},
+            {"parameter": "leverage", "metric": "Sortino", "min_value": 0.1, "max_value": 2.0, "step": 0.1},
+            {"parameter": "sma_filter_window", "metric": "Sortino", "min_value": 2, "max_value": 24, "step": 1},
+            {"parameter": "derisk_days_under_sma", "metric": "Sortino", "min_value": 0, "max_value": 30, "step": 1},
+            {"parameter": "sizer_beta_window", "metric": "Sortino", "min_value": 2, "max_value": 12, "step": 1}
+        ],
+        "strategy_params": {
+            "long_only": True,
+            "sizer_beta_window": 3
+        },
+        "mc_simulations": 1000,
+        "mc_years": 10
+    },
+    {
         "name": "Momentum_SMA_Filtered",
         "strategy": "momentum",
         "rebalance_frequency": "ME",
@@ -433,5 +458,6 @@ OPTIMIZER_PARAMETER_DEFAULTS = {
   "sizer_sharpe_window": {"type": "int", "low": 2, "high": 12, "step": 1},
   "sizer_sortino_window": {"type": "int", "low": 2, "high": 12, "step": 1},
   "sizer_beta_window": {"type": "int", "low": 2, "high": 12, "step": 1},
-  "sizer_corr_window": {"type": "int", "low": 2, "high": 12, "step": 1}
+  "sizer_corr_window": {"type": "int", "low": 2, "high": 12, "step": 1},
+  "long_only": {"type": "int", "low": 0, "high": 1, "step": 1}
 }


### PR DESCRIPTION
## Summary
- add automatic mapping for sizer parameters in `Backtester`
- provide Momentum_Beta_Sized scenario using rolling beta position sizing
- expose `long_only` in optimizer defaults

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68655557b2848333a27d081f148f0c18