### PR TITLE
Add downside volatility sizer and strategy scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,8 @@ Individual scenarios in `BACKTEST_SCENARIOS` can still override these defaults b
 │   │       ├───base_strategy.py: Abstract base class for trading strategies.
 │   │       ├───momentum_strategy.py: Implements a basic momentum strategy.
 │   │       ├───sharpe_momentum_strategy.py: Implements a Sharpe ratio-based momentum strategy.
-│   │       └───vams_momentum_strategy.py: Implements a VAMS (Volatility-Adjusted Momentum Strategy).
+│   │       ├───vams_momentum_strategy.py: Implements a VAMS (Volatility-Adjusted Momentum Strategy).
+│   │       └───momentum_dvol_sizer_strategy.py: Momentum strategy using downside-volatility sizing.
 │   └───portfolio_backtester.egg-info/: Metadata for the Python package.
 └───tests/: Unit and integration tests for the project.
     ├───__init__.py: Initializes the tests package.
@@ -234,7 +235,8 @@ Individual scenarios in `BACKTEST_SCENARIOS` can still override these defaults b
     │   └───test_performance_metrics.py: Tests for performance metrics calculation.
     └───strategies/: Tests for trading strategies.
         ├───__init__.py: Initializes the strategies tests package.
-        └───test_momentum_strategy.py: Tests for the momentum strategy.
+        ├───test_momentum_strategy.py: Tests for the momentum strategy.
+        └───test_momentum_dvol_sizer_strategy.py: Tests for the momentum strategy using downside-volatility sizing.
 ```
 
 ### Development Practices and Standards

--- a/src/portfolio_backtester/backtester.py
+++ b/src/portfolio_backtester/backtester.py
@@ -143,6 +143,7 @@ class Backtester:
             "sizer_sortino_window": "window",
             "sizer_beta_window": "window",
             "sizer_corr_window": "window",
+            "sizer_dvol_window": "window",
             "sizer_target_return": "target_return", # For Sortino sizer
         }
         for old_key, new_key in sizer_param_mapping.items():

--- a/src/portfolio_backtester/config.py
+++ b/src/portfolio_backtester/config.py
@@ -55,6 +55,30 @@ BACKTEST_SCENARIOS = [
         "mc_years": 10
     },
     {
+        "name": "Momentum_DVOL_Sizer",
+        "strategy": "momentum_dvol_sizer",
+        "rebalance_frequency": "ME",
+        "position_sizer": "rolling_downside_volatility",
+        "transaction_costs_bps": 10,
+        "train_window_months": 60,
+        "test_window_months": 24,
+        "optimize": [
+            {"parameter": "num_holdings", "metric": "Total Return", "min_value": 10, "max_value": 35, "step": 1},
+            {"parameter": "top_decile_fraction", "metric": "Total Return", "min_value": 0.05, "max_value": 0.3, "step": 0.01},
+            {"parameter": "lookback_months", "metric": "Total Return", "min_value": 3, "max_value": 14, "step": 1},
+            {"parameter": "smoothing_lambda", "metric": "Total Return", "min_value": 0.0, "max_value": 1.0, "step": 0.05},
+            {"parameter": "leverage", "metric": "Total Return", "min_value": 0.1, "max_value": 2.0, "step": 0.1},
+            {"parameter": "sma_filter_window", "metric": "Total Return", "min_value": 2, "max_value": 24, "step": 1},
+            {"parameter": "derisk_days_under_sma", "metric": "Total Return", "min_value": 0, "max_value": 30, "step": 1},
+            {"parameter": "sizer_dvol_window", "metric": "Total Return", "min_value": 2, "max_value": 12, "step": 1}
+        ],
+        "strategy_params": {
+            "long_only": True
+        },
+        "mc_simulations": 1000,
+        "mc_years": 10
+    },
+    {
         "name": "Momentum_SMA_Filtered",
         "strategy": "momentum",
         "rebalance_frequency": "ME",
@@ -457,6 +481,7 @@ OPTIMIZER_PARAMETER_DEFAULTS = {
   "sizer_sortino_window": {"type": "int", "low": 2, "high": 12, "step": 1},
   "sizer_beta_window": {"type": "int", "low": 2, "high": 12, "step": 1},
   "sizer_corr_window": {"type": "int", "low": 2, "high": 12, "step": 1},
+  "sizer_dvol_window": {"type": "int", "low": 2, "high": 12, "step": 1},
   "long_only": {"type": "int", "low": 0, "high": 1, "step": 1}
 }
 
@@ -471,6 +496,7 @@ def populate_default_optimizations():
         "rolling_sortino": "sizer_sortino_window",
         "rolling_beta": "sizer_beta_window",
         "rolling_benchmark_corr": "sizer_corr_window",
+        "rolling_downside_volatility": "sizer_dvol_window",
     }
 
     for scen in BACKTEST_SCENARIOS:

--- a/src/portfolio_backtester/spy_holdings.py
+++ b/src/portfolio_backtester/spy_holdings.py
@@ -25,7 +25,12 @@ import pandas as pd
 import requests
 from lxml import etree
 from tqdm import tqdm
-from edgar import set_identity, Company        # EdgarTools ≥4.3.0
+try:  # EdgarTools ≥4.3.0 provides set_identity
+    from edgar import set_identity, Company
+except Exception:  # pragma: no cover - fallback for missing API
+    import edgar
+    set_identity = getattr(edgar, "set_identity", lambda _: None)
+    Company = getattr(edgar, "Company", None)
 import json
 from urllib.parse import quote
 from httpx import HTTPStatusError

--- a/src/portfolio_backtester/strategies/__init__.py
+++ b/src/portfolio_backtester/strategies/__init__.py
@@ -5,6 +5,7 @@ from .vams_momentum_strategy import VAMSMomentumStrategy
 from .sortino_momentum_strategy import SortinoMomentumStrategy
 from .calmar_momentum_strategy import CalmarMomentumStrategy
 from .vams_no_downside_strategy import VAMSNoDownsideStrategy
+from .momentum_dvol_sizer_strategy import MomentumDvolSizerStrategy
 
 __all__ = [
     "BaseStrategy",
@@ -14,4 +15,5 @@ __all__ = [
     "SortinoMomentumStrategy",
     "CalmarMomentumStrategy",
     "VAMSNoDownsideStrategy",
+    "MomentumDvolSizerStrategy",
 ]

--- a/src/portfolio_backtester/strategies/momentum_dvol_sizer_strategy.py
+++ b/src/portfolio_backtester/strategies/momentum_dvol_sizer_strategy.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+"""Momentum strategy using downside volatility for position sizing."""
+
+from .momentum_strategy import MomentumStrategy
+
+
+class MomentumDvolSizerStrategy(MomentumStrategy):
+    """Momentum strategy that sizes positions by downside volatility."""
+
+    def __init__(self, strategy_config: dict) -> None:
+        cfg = dict(strategy_config)
+        cfg.setdefault("position_sizer", "rolling_downside_volatility")
+        super().__init__(cfg)
+
+    @classmethod
+    def tunable_parameters(cls) -> set[str]:
+        return MomentumStrategy.tunable_parameters().union({"sizer_dvol_window"})
+
+
+

--- a/src/portfolio_backtester/utils.py
+++ b/src/portfolio_backtester/utils.py
@@ -57,6 +57,7 @@ def _run_scenario_static(
         "sizer_sortino_window": "window",
         "sizer_beta_window": "window",
         "sizer_corr_window": "window",
+        "sizer_dvol_window": "window",
         "sizer_target_return": "target_return",  # For Sortino sizer
     }
     for old_key, new_key in sizer_param_mapping.items():

--- a/tests/strategies/test_momentum_dvol_sizer_strategy.py
+++ b/tests/strategies/test_momentum_dvol_sizer_strategy.py
@@ -1,0 +1,33 @@
+import unittest
+import pandas as pd
+import numpy as np
+
+from src.portfolio_backtester.strategies.momentum_dvol_sizer_strategy import MomentumDvolSizerStrategy
+from src.portfolio_backtester.feature_engineering import precompute_features
+
+
+class TestMomentumDvolSizerStrategy(unittest.TestCase):
+    def setUp(self):
+        dates = pd.to_datetime(pd.date_range(start='2020-01-01', periods=12, freq='ME'))
+        self.data = pd.DataFrame({
+            'A': np.linspace(100, 200, 12),
+            'B': np.linspace(100, 50, 12),
+        }, index=dates)
+        self.benchmark = pd.Series(np.linspace(100, 120, 12), index=dates, name='SPY')
+
+    def test_resolve_and_defaults(self):
+        strategy = MomentumDvolSizerStrategy({'lookback_months': 3})
+        self.assertEqual(strategy.strategy_config['position_sizer'], 'rolling_downside_volatility')
+
+    def test_generate_signals_smoke(self):
+        strategy_config = {'lookback_months': 3}
+        strategy = MomentumDvolSizerStrategy(strategy_config)
+        required = strategy.get_required_features({'strategy_params': strategy_config})
+        features = precompute_features(self.data, required, self.benchmark)
+        signals = strategy.generate_signals(self.data, features, self.benchmark)
+        self.assertEqual(signals.shape, self.data.shape)
+
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- implement `MomentumDvolSizerStrategy` using new downside volatility sizer
- fallback import handling for `edgar` in spy_holdings
- hook up strategy in config and registry
- add unit test for the new strategy
- document new strategy and its test locations

## Testing
- `pip install -e .`
- `pip install edgar`
- `pip install httpx`
- `pip install setuptools`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686569cf872c8333b65d646a02e5230d