### PR TITLE
Add volatility targeting framework

### DIFF
--- a/src/portfolio_backtester/backtester.py
+++ b/src/portfolio_backtester/backtester.py
@@ -194,6 +194,9 @@ class Backtester:
         portfolio_rets_net = (
             portfolio_rets_gross - transaction_costs
         ).reindex(price_data_daily.index).fillna(0)
+
+        vt = strategy.get_volatility_targeting()
+        portfolio_rets_net = vt.adjust_returns(portfolio_rets_net)
         if verbose:
             logger.info(f"Portfolio returns calculated for {scenario_config['name']}. First few returns: {portfolio_rets_net.head().to_dict()}")
             logger.info(f"portfolio_rets_gross index: {portfolio_rets_gross.index.min()} to {portfolio_rets_gross.index.max()}")

--- a/src/portfolio_backtester/portfolio/__init__.py
+++ b/src/portfolio_backtester/portfolio/__init__.py
@@ -1,1 +1,31 @@
-  
+"""Portfolio management utilities."""
+
+from .position_sizer import (
+    equal_weight_sizer,
+    rolling_sharpe_sizer,
+    rolling_sortino_sizer,
+    rolling_beta_sizer,
+    rolling_benchmark_corr_sizer,
+    rolling_downside_volatility_sizer,
+    get_position_sizer,
+)
+from .rebalancing import rebalance
+from .volatility_targeting import (
+    BaseVolatilityTargeting,
+    NoVolatilityTargeting,
+    AnnualizedVolatilityTargeting,
+)
+
+__all__ = [
+    "equal_weight_sizer",
+    "rolling_sharpe_sizer",
+    "rolling_sortino_sizer",
+    "rolling_beta_sizer",
+    "rolling_benchmark_corr_sizer",
+    "rolling_downside_volatility_sizer",
+    "get_position_sizer",
+    "rebalance",
+    "BaseVolatilityTargeting",
+    "NoVolatilityTargeting",
+    "AnnualizedVolatilityTargeting",
+]

--- a/src/portfolio_backtester/portfolio/volatility_targeting.py
+++ b/src/portfolio_backtester/portfolio/volatility_targeting.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+import pandas as pd
+import numpy as np
+
+
+class BaseVolatilityTargeting(ABC):
+    """Interface for portfolio-level volatility targeting."""
+
+    def __init__(self, target_vol: float | None = None):
+        self.target_vol = target_vol
+
+    @abstractmethod
+    def adjust_returns(self, returns: pd.Series) -> pd.Series:
+        """Adjust a return series according to the implemented rule."""
+        raise NotImplementedError
+
+
+class NoVolatilityTargeting(BaseVolatilityTargeting):
+    """Dummy implementation that leaves returns unchanged."""
+
+    def adjust_returns(self, returns: pd.Series) -> pd.Series:
+        return returns
+
+
+@dataclass
+class AnnualizedVolatilityTargeting(BaseVolatilityTargeting):
+    """Scale returns to achieve a constant annualized volatility."""
+
+    target_vol: float | None = None
+    window: int = 20
+    ann_factor: int = 252
+    max_leverage: float = 3.0
+
+    def adjust_returns(self, returns: pd.Series) -> pd.Series:
+        if self.target_vol is None:
+            return returns
+        rolling_vol = returns.rolling(self.window).std() * np.sqrt(self.ann_factor)
+        scaling = (self.target_vol / rolling_vol).shift(1)
+        scaling = scaling.clip(upper=self.max_leverage).fillna(1.0)
+        return returns * scaling
+
+
+__all__ = [
+    "BaseVolatilityTargeting",
+    "NoVolatilityTargeting",
+    "AnnualizedVolatilityTargeting",
+]

--- a/src/portfolio_backtester/strategies/base_strategy.py
+++ b/src/portfolio_backtester/strategies/base_strategy.py
@@ -8,6 +8,10 @@ import pandas as pd
 
 from ..feature import Feature, BenchmarkSMA
 from ..portfolio.position_sizer import get_position_sizer
+from ..portfolio.volatility_targeting import (
+    BaseVolatilityTargeting,
+    NoVolatilityTargeting,
+)
 from ..signal_generators import BaseSignalGenerator
 
 
@@ -16,6 +20,8 @@ class BaseStrategy(ABC):
 
     #: class attribute specifying which signal generator to use
     signal_generator_class: type[BaseSignalGenerator] | None = None
+    #: class attribute specifying which volatility targeting implementation to use
+    volatility_targeting_class: type[BaseVolatilityTargeting] = NoVolatilityTargeting
 
     def __init__(self, strategy_config: dict):
         self.strategy_config = strategy_config
@@ -35,6 +41,10 @@ class BaseStrategy(ABC):
 
     def get_volatility_target(self) -> float | None:
         return self.strategy_config.get("volatility_target")
+
+    def get_volatility_targeting(self) -> BaseVolatilityTargeting:
+        target = self.get_volatility_target()
+        return self.volatility_targeting_class(target)
 
     # ------------------------------------------------------------------ #
     # Required features

--- a/src/portfolio_backtester/utils.py
+++ b/src/portfolio_backtester/utils.py
@@ -82,4 +82,7 @@ def _run_scenario_static(
     turn = (weights_daily - weights_daily.shift(1)).abs().sum(axis=1)
     tc = turn * (scenario_cfg["transaction_costs_bps"] / 10_000)
 
-    return (gross - tc).reindex(price_daily.index).fillna(0)
+    returns = (gross - tc).reindex(price_daily.index).fillna(0)
+
+    vt = strategy.get_volatility_targeting()
+    return vt.adjust_returns(returns)

--- a/tests/portfolio/test_volatility_targeting.py
+++ b/tests/portfolio/test_volatility_targeting.py
@@ -1,0 +1,30 @@
+import unittest
+import pandas as pd
+import numpy as np
+
+from src.portfolio_backtester.portfolio.volatility_targeting import (
+    NoVolatilityTargeting,
+    AnnualizedVolatilityTargeting,
+)
+
+
+class TestVolatilityTargeting(unittest.TestCase):
+    def setUp(self):
+        dates = pd.date_range("2020-01-01", periods=100, freq="D")
+        np.random.seed(0)
+        self.returns = pd.Series(np.random.normal(0, 0.01, len(dates)), index=dates)
+
+    def test_no_volatility_targeting(self):
+        vt = NoVolatilityTargeting()
+        pd.testing.assert_series_equal(vt.adjust_returns(self.returns), self.returns)
+
+    def test_annualized_targeting_scales_returns(self):
+        vt = AnnualizedVolatilityTargeting(target_vol=0.1, window=5, ann_factor=252)
+        adjusted = vt.adjust_returns(self.returns)
+        # After enough observations, volatility should be near target
+        realized_vol = adjusted.std() * np.sqrt(252)
+        self.assertAlmostEqual(realized_vol, 0.1, delta=0.07)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement portfolio-level volatility targeting classes
- plug volatility targeting into backtester and optimization utilities
- expose volatility targeting through strategies
- test annualized and dummy implementations

## Testing
- `pip install -q -e .`
- `pip install -q httpx`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68657b0241b0833386b583f5a297ad36