### PR TITLE
Add portfolio-level volatility targeting

### DIFF
--- a/src/portfolio_backtester/backtester.py
+++ b/src/portfolio_backtester/backtester.py
@@ -194,6 +194,9 @@ class Backtester:
         portfolio_rets_net = (
             portfolio_rets_gross - transaction_costs
         ).reindex(price_data_daily.index).fillna(0)
+
+        vt = strategy.get_volatility_targeting()
+        portfolio_rets_net = vt.adjust_returns(portfolio_rets_net)
         if verbose:
             logger.info(f"Portfolio returns calculated for {scenario_config['name']}. First few returns: {portfolio_rets_net.head().to_dict()}")
             logger.info(f"portfolio_rets_gross index: {portfolio_rets_gross.index.min()} to {portfolio_rets_gross.index.max()}")

--- a/src/portfolio_backtester/portfolio/__init__.py
+++ b/src/portfolio_backtester/portfolio/__init__.py
@@ -1,1 +1,13 @@
-  
+"""Portfolio utilities and helpers."""
+
+from .volatility_targeting import (
+    VolatilityTargetingMethod,
+    NoVolatilityTargeting,
+    AnnualizedVolatilityTargeting,
+)
+
+__all__ = [
+    "VolatilityTargetingMethod",
+    "NoVolatilityTargeting",
+    "AnnualizedVolatilityTargeting",
+]

--- a/src/portfolio_backtester/portfolio/volatility_targeting.py
+++ b/src/portfolio_backtester/portfolio/volatility_targeting.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+import numpy as np
+import pandas as pd
+
+class VolatilityTargetingMethod(ABC):
+    """Interface for portfolio-level volatility targeting."""
+
+    @abstractmethod
+    def adjust_returns(self, returns: pd.Series) -> pd.Series:
+        """Scale portfolio returns according to the targeting rule."""
+        raise NotImplementedError
+
+
+class NoVolatilityTargeting(VolatilityTargetingMethod):
+    """Dummy implementation that performs no volatility targeting."""
+
+    def adjust_returns(self, returns: pd.Series) -> pd.Series:  # noqa: D401
+        """Return the input unchanged."""
+        return returns
+
+
+class AnnualizedVolatilityTargeting(VolatilityTargetingMethod):
+    """Target a constant annualized volatility by scaling returns."""
+
+    def __init__(self, target_vol: float, window: int = 63, max_leverage: float = 3.0) -> None:
+        self.target_vol = float(target_vol)
+        self.window = int(window)
+        self.max_leverage = float(max_leverage)
+
+    def adjust_returns(self, returns: pd.Series) -> pd.Series:
+        if returns.empty:
+            return returns
+        # Realized volatility based on trailing window, shifted to avoid look-ahead
+        realized_vol = returns.rolling(self.window).std().shift(1) * np.sqrt(252)
+        scaling = self.target_vol / realized_vol
+        scaling = scaling.clip(upper=self.max_leverage).fillna(1.0)
+        return returns * scaling
+

--- a/src/portfolio_backtester/strategies/calmar_momentum_strategy.py
+++ b/src/portfolio_backtester/strategies/calmar_momentum_strategy.py
@@ -2,12 +2,14 @@ from typing import Set
 
 from .base_strategy import BaseStrategy
 from ..signal_generators import CalmarSignalGenerator
+from ..portfolio.volatility_targeting import NoVolatilityTargeting
 
 
 class CalmarMomentumStrategy(BaseStrategy):
     """Momentum strategy implementation using Calmar ratio for ranking."""
 
     signal_generator_class = CalmarSignalGenerator
+    volatility_targeting_class = NoVolatilityTargeting
 
     @classmethod
     def tunable_parameters(cls) -> set[str]:

--- a/src/portfolio_backtester/strategies/momentum_dvol_sizer_strategy.py
+++ b/src/portfolio_backtester/strategies/momentum_dvol_sizer_strategy.py
@@ -3,10 +3,13 @@ from __future__ import annotations
 """Momentum strategy using downside volatility for position sizing."""
 
 from .momentum_strategy import MomentumStrategy
+from ..portfolio.volatility_targeting import NoVolatilityTargeting
 
 
 class MomentumDvolSizerStrategy(MomentumStrategy):
     """Momentum strategy that sizes positions by downside volatility."""
+
+    volatility_targeting_class = NoVolatilityTargeting
 
     def __init__(self, strategy_config: dict) -> None:
         cfg = dict(strategy_config)

--- a/src/portfolio_backtester/strategies/momentum_strategy.py
+++ b/src/portfolio_backtester/strategies/momentum_strategy.py
@@ -2,12 +2,14 @@ from typing import Set
 
 from .base_strategy import BaseStrategy
 from ..signal_generators import MomentumSignalGenerator
+from ..portfolio.volatility_targeting import NoVolatilityTargeting
 
 
 class MomentumStrategy(BaseStrategy):
     """Momentum strategy implementation."""
 
     signal_generator_class = MomentumSignalGenerator
+    volatility_targeting_class = NoVolatilityTargeting
 
     @classmethod
     def tunable_parameters(cls) -> set[str]:

--- a/src/portfolio_backtester/strategies/sharpe_momentum_strategy.py
+++ b/src/portfolio_backtester/strategies/sharpe_momentum_strategy.py
@@ -2,12 +2,14 @@ from typing import Set
 
 from .base_strategy import BaseStrategy
 from ..signal_generators import SharpeSignalGenerator
+from ..portfolio.volatility_targeting import NoVolatilityTargeting
 
 
 class SharpeMomentumStrategy(BaseStrategy):
     """Momentum strategy implementation using Sharpe ratio for ranking."""
 
     signal_generator_class = SharpeSignalGenerator
+    volatility_targeting_class = NoVolatilityTargeting
 
     @classmethod
     def tunable_parameters(cls) -> set[str]:

--- a/src/portfolio_backtester/strategies/sortino_momentum_strategy.py
+++ b/src/portfolio_backtester/strategies/sortino_momentum_strategy.py
@@ -2,12 +2,14 @@ from typing import Set
 
 from .base_strategy import BaseStrategy
 from ..signal_generators import SortinoSignalGenerator
+from ..portfolio.volatility_targeting import NoVolatilityTargeting
 
 
 class SortinoMomentumStrategy(BaseStrategy):
     """Momentum strategy implementation using Sortino ratio for ranking."""
 
     signal_generator_class = SortinoSignalGenerator
+    volatility_targeting_class = NoVolatilityTargeting
 
     @classmethod
     def tunable_parameters(cls) -> set[str]:

--- a/src/portfolio_backtester/strategies/vams_momentum_strategy.py
+++ b/src/portfolio_backtester/strategies/vams_momentum_strategy.py
@@ -2,12 +2,14 @@ from typing import Set
 
 from .base_strategy import BaseStrategy
 from ..signal_generators import DPVAMSSignalGenerator
+from ..portfolio.volatility_targeting import NoVolatilityTargeting
 
 
 class VAMSMomentumStrategy(BaseStrategy):
     """Momentum strategy implementation using Volatility Adjusted Momentum Scores (VAMS)."""
 
     signal_generator_class = DPVAMSSignalGenerator
+    volatility_targeting_class = NoVolatilityTargeting
 
     @classmethod
     def tunable_parameters(cls) -> set[str]:

--- a/src/portfolio_backtester/strategies/vams_no_downside_strategy.py
+++ b/src/portfolio_backtester/strategies/vams_no_downside_strategy.py
@@ -2,12 +2,14 @@ from typing import Set
 
 from .base_strategy import BaseStrategy
 from ..signal_generators import VAMSSignalGenerator
+from ..portfolio.volatility_targeting import NoVolatilityTargeting
 
 
 class VAMSNoDownsideStrategy(BaseStrategy):
     """Momentum strategy implementation using Volatility Adjusted Momentum Scores (VAMS), without downside volatility penalization."""
 
     signal_generator_class = VAMSSignalGenerator
+    volatility_targeting_class = NoVolatilityTargeting
 
     @classmethod
     def tunable_parameters(cls) -> set[str]:

--- a/src/portfolio_backtester/utils.py
+++ b/src/portfolio_backtester/utils.py
@@ -81,5 +81,6 @@ def _run_scenario_static(
     gross = (weights_daily.shift(1).fillna(0.0) * rets_daily).sum(axis=1)
     turn = (weights_daily - weights_daily.shift(1)).abs().sum(axis=1)
     tc = turn * (scenario_cfg["transaction_costs_bps"] / 10_000)
-
-    return (gross - tc).reindex(price_daily.index).fillna(0)
+    net = (gross - tc).reindex(price_daily.index).fillna(0)
+    vt = strategy.get_volatility_targeting()
+    return vt.adjust_returns(net)

--- a/tests/portfolio/test_volatility_targeting.py
+++ b/tests/portfolio/test_volatility_targeting.py
@@ -1,0 +1,26 @@
+import unittest
+import pandas as pd
+
+from src.portfolio_backtester.portfolio.volatility_targeting import (
+    NoVolatilityTargeting,
+    AnnualizedVolatilityTargeting,
+)
+
+
+class TestVolatilityTargeting(unittest.TestCase):
+    def test_no_volatility_targeting_pass_through(self):
+        rets = pd.Series([0.01, -0.02, 0.03])
+        vt = NoVolatilityTargeting()
+        pd.testing.assert_series_equal(vt.adjust_returns(rets), rets)
+
+    def test_annualized_volatility_targeting_scales_returns(self):
+        dates = pd.date_range("2020-01-01", periods=6, freq="D")
+        rets = pd.Series(0.01, index=dates)
+        vt = AnnualizedVolatilityTargeting(target_vol=0.2, window=3, max_leverage=2.0)
+        scaled = vt.adjust_returns(rets)
+        self.assertTrue((scaled.iloc[:3] == 0.01).all())
+        self.assertTrue((scaled.iloc[3:] == 0.02).all())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- introduce a modular volatility targeting framework
- scale portfolio returns using annualized volatility targeting
- implement default NoVolatilityTargeting across strategies
- expose volatility targeting utilities
- test new volatility targeting logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68657b0241b0833386b583f5a297ad36