### PR TITLE
Refactor: Unify optimization metric at scenario level

### DIFF
--- a/src/portfolio_backtester/backtester.py
+++ b/src/portfolio_backtester/backtester.py
@@ -400,8 +400,8 @@ class Backtester:
             train_data_daily,
             train_rets_sliced,
             daily_data[self.global_config["benchmark"]],
-            train_features_sliced,
-            metric=scenario_config["optimize"][0]["metric"]
+            train_features_sliced
+            # metric is now sourced from scenario_config within build_objective
         )
 
         with Progress(

--- a/src/portfolio_backtester/config.py
+++ b/src/portfolio_backtester/config.py
@@ -13,14 +13,15 @@ BACKTEST_SCENARIOS = [
         "transaction_costs_bps": 10,
         "train_window_months": 60,
         "test_window_months": 24,
+        "optimization_metric": "Sortino", # Added scenario-level metric
         "optimize": [
-            {"parameter": "num_holdings", "metric": "Sortino", "min_value": 10, "max_value": 35, "step": 1},
-            {"parameter": "top_decile_fraction", "metric": "Sortino", "min_value": 0.05, "max_value": 0.3, "step": 0.01},
-            {"parameter": "lookback_months", "metric": "Sortino", "min_value": 3, "max_value": 14, "step": 1},
-            {"parameter": "smoothing_lambda", "metric": "Sortino", "min_value": 0.0, "max_value": 1.0, "step": 0.05},
-            {"parameter": "leverage", "metric": "Sortino", "min_value": 0.1, "max_value": 2.0, "step": 0.1},
-            {"parameter": "sma_filter_window", "metric": "Sortino", "min_value": 2, "max_value": 24, "step": 1},
-            {"parameter": "derisk_days_under_sma", "metric": "Sortino", "min_value": 0, "max_value": 30, "step": 1}
+            {"parameter": "num_holdings", "min_value": 10, "max_value": 35, "step": 1},
+            {"parameter": "top_decile_fraction", "min_value": 0.05, "max_value": 0.3, "step": 0.01},
+            {"parameter": "lookback_months", "min_value": 3, "max_value": 14, "step": 1},
+            {"parameter": "smoothing_lambda", "min_value": 0.0, "max_value": 1.0, "step": 0.05},
+            {"parameter": "leverage", "min_value": 0.1, "max_value": 2.0, "step": 0.1},
+            {"parameter": "sma_filter_window", "min_value": 2, "max_value": 24, "step": 1},
+            {"parameter": "derisk_days_under_sma", "min_value": 0, "max_value": 30, "step": 1}
         ],
         "strategy_params": {
             # All optimized parameters are omitted here
@@ -37,15 +38,16 @@ BACKTEST_SCENARIOS = [
         "transaction_costs_bps": 10,
         "train_window_months": 60,
         "test_window_months": 24,
+        "optimization_metric": "Sortino", # Added scenario-level metric
         "optimize": [
-            {"parameter": "num_holdings", "metric": "Sortino", "min_value": 10, "max_value": 35, "step": 1},
-            {"parameter": "top_decile_fraction", "metric": "Sortino", "min_value": 0.05, "max_value": 0.3, "step": 0.01},
-            {"parameter": "lookback_months", "metric": "Sortino", "min_value": 3, "max_value": 14, "step": 1},
-            {"parameter": "smoothing_lambda", "metric": "Sortino", "min_value": 0.0, "max_value": 1.0, "step": 0.05},
-            {"parameter": "leverage", "metric": "Sortino", "min_value": 0.1, "max_value": 2.0, "step": 0.1},
-            {"parameter": "sma_filter_window", "metric": "Sortino", "min_value": 2, "max_value": 24, "step": 1},
-            {"parameter": "derisk_days_under_sma", "metric": "Sortino", "min_value": 0, "max_value": 30, "step": 1},
-            {"parameter": "sizer_beta_window", "metric": "Sortino", "min_value": 2, "max_value": 12, "step": 1}
+            {"parameter": "num_holdings", "min_value": 10, "max_value": 35, "step": 1},
+            {"parameter": "top_decile_fraction", "min_value": 0.05, "max_value": 0.3, "step": 0.01},
+            {"parameter": "lookback_months", "min_value": 3, "max_value": 14, "step": 1},
+            {"parameter": "smoothing_lambda", "min_value": 0.0, "max_value": 1.0, "step": 0.05},
+            {"parameter": "leverage", "min_value": 0.1, "max_value": 2.0, "step": 0.1},
+            {"parameter": "sma_filter_window", "min_value": 2, "max_value": 24, "step": 1},
+            {"parameter": "derisk_days_under_sma", "min_value": 0, "max_value": 30, "step": 1},
+            {"parameter": "sizer_beta_window", "min_value": 2, "max_value": 12, "step": 1}
         ],
         "strategy_params": {
             "long_only": True,
@@ -62,16 +64,17 @@ BACKTEST_SCENARIOS = [
         "transaction_costs_bps": 10,
         "train_window_months": 60,
         "test_window_months": 24,
+        "optimization_metric": "Total Return", # Added scenario-level metric
         "optimize": [
-            {"parameter": "num_holdings", "metric": "Total Return", "min_value": 10, "max_value": 35, "step": 1},
-            {"parameter": "top_decile_fraction", "metric": "Total Return", "min_value": 0.05, "max_value": 0.3, "step": 0.01},
-            {"parameter": "lookback_months", "metric": "Total Return", "min_value": 3, "max_value": 14, "step": 1},
-            {"parameter": "smoothing_lambda", "metric": "Total Return", "min_value": 0.0, "max_value": 1.0, "step": 0.05},
-            {"parameter": "leverage", "metric": "Total Return", "min_value": 0.1, "max_value": 2.0, "step": 0.1},
-            {"parameter": "sma_filter_window", "metric": "Total Return", "min_value": 2, "max_value": 24, "step": 1},
-            {"parameter": "derisk_days_under_sma", "metric": "Total Return", "min_value": 0, "max_value": 30, "step": 1},
-            {"parameter": "sizer_dvol_window", "metric": "Total Return", "min_value": 2, "max_value": 12, "step": 1},
-            {"parameter": "target_volatility", "metric": "Total Return", "min_value": 0.05, "max_value": 0.3, "step": 0.01}
+            {"parameter": "num_holdings", "min_value": 10, "max_value": 35, "step": 1},
+            {"parameter": "top_decile_fraction", "min_value": 0.05, "max_value": 0.3, "step": 0.01},
+            {"parameter": "lookback_months", "min_value": 3, "max_value": 14, "step": 1},
+            {"parameter": "smoothing_lambda", "min_value": 0.0, "max_value": 1.0, "step": 0.05},
+            {"parameter": "leverage", "min_value": 0.1, "max_value": 2.0, "step": 0.1},
+            {"parameter": "sma_filter_window", "min_value": 2, "max_value": 24, "step": 1},
+            {"parameter": "derisk_days_under_sma", "min_value": 0, "max_value": 30, "step": 1},
+            {"parameter": "sizer_dvol_window", "min_value": 2, "max_value": 12, "step": 1},
+            {"parameter": "target_volatility", "min_value": 0.05, "max_value": 0.3, "step": 0.01}
         ],
         "strategy_params": {
             "long_only": True
@@ -87,17 +90,16 @@ BACKTEST_SCENARIOS = [
         "transaction_costs_bps": 10,
         "train_window_months": 24,
         "test_window_months": 12,
+        "optimization_metric": "Total Return", # Added scenario-level metric
         "optimize": [
             {
                 "parameter": "num_holdings",
-                "metric": "Total Return",
                 "min_value": 10,
                 "max_value": 30,
                 "step": 1
             },
             {
                 "parameter": "derisk_days_under_sma",
-                "metric": "Total Return",
                 "min_value": 1,
                 "max_value": 30,
                 "step": 1
@@ -123,17 +125,16 @@ BACKTEST_SCENARIOS = [
         "transaction_costs_bps": 10,
         "train_window_months": 24,
         "test_window_months": 12,
+        "optimization_metric": "Sharpe", # Added scenario-level metric
         "optimize": [
             {
                 "parameter": "num_holdings",
-                "metric": "Sharpe",
                 "min_value": 10,
                 "max_value": 30,
                 "step": 1
             },
             {
                 "parameter": "rolling_window",
-                "metric": "Sharpe",
                 "min_value": 1,
                 "max_value": 6,
                 "step": 1
@@ -158,6 +159,7 @@ BACKTEST_SCENARIOS = [
         "transaction_costs_bps": 10,
         "train_window_months": 24, # Use a 24-month training window
         "test_window_months": 12, # Test on the next 12 months
+        "optimization_metric": "Sortino", # Added scenario-level metric
         "strategy_params": {
             "long_only": True,
             "sma_filter_window": None,
@@ -167,42 +169,36 @@ BACKTEST_SCENARIOS = [
         "optimize": [
             {
                 "parameter": "num_holdings",
-                "metric": "Sortino",
                 "min_value": 10,
                 "max_value": 30,
                 "step": 1
             },
             {
                 "parameter": "lookback_months",
-                "metric": "Sortino",
                 "min_value": 3,
                 "max_value": 24,
                 "step": 1,
             },
             {
                 "parameter": "top_decile_fraction",
-                "metric": "Sortino",
                 "min_value": 0.05,
                 "max_value": 0.20,
                 "step": 0.05,
             },
             {
                 "parameter": "smoothing_lambda",
-                "metric": "Sortino",
                 "min_value": 0.1,
                 "max_value": 0.9,
                 "step": 0.1,
             },
             {
                 "parameter": "leverage",
-                "metric": "Sortino",
                 "min_value": 0.1,
                 "max_value": 2.0,
                 "step": 0.1,
             },
             {
                 "parameter": "alpha",
-                "metric": "Sortino",
                 "min_value": 0.0,
                 "max_value": 1.0,
                 "step": 0.1,
@@ -217,6 +213,7 @@ BACKTEST_SCENARIOS = [
         "transaction_costs_bps": 10,
         "train_window_months": 24, # Use a 24-month training window
         "test_window_months": 12, # Test on the next 12 months
+        "optimization_metric": "Sortino", # Added scenario-level metric
         "strategy_params": {
             "long_only": True,
             "sma_filter_window": None,
@@ -226,35 +223,30 @@ BACKTEST_SCENARIOS = [
         "optimize": [
             {
                 "parameter": "num_holdings",
-                "metric": "Sortino",
                 "min_value": 10,
                 "max_value": 30,
                 "step": 1
             },
             {
                 "parameter": "lookback_months",
-                "metric": "Sortino",
                 "min_value": 6,
                 "max_value": 24,
                 "step": 1,
             },
             {
                 "parameter": "top_decile_fraction",
-                "metric": "Sortino",
                 "min_value": 0.05,
                 "max_value": 0.20,
                 "step": 0.05,
             },
             {
                 "parameter": "smoothing_lambda",
-                "metric": "Sortino",
                 "min_value": 0.1,
                 "max_value": 0.9,
                 "step": 0.1,
             },
             {
                 "parameter": "leverage",
-                "metric": "Sortino",
                 "min_value": 0.1,
                 "max_value": 1.0,
                 "step": 0.1,
@@ -269,17 +261,16 @@ BACKTEST_SCENARIOS = [
         "transaction_costs_bps": 10,
         "train_window_months": 24,
         "test_window_months": 12,
+        "optimization_metric": "Sortino", # Added scenario-level metric
         "optimize": [
             {
                 "parameter": "num_holdings",
-                "metric": "Sortino",
                 "min_value": 10,
                 "max_value": 30,
                 "step": 1
             },
             {
                 "parameter": "rolling_window",
-                "metric": "Sortino",
                 "min_value": 1,
                 "max_value": 6,
                 "step": 1
@@ -305,17 +296,16 @@ BACKTEST_SCENARIOS = [
         "transaction_costs_bps": 10,
         "train_window_months": 24,
         "test_window_months": 12,
+        "optimization_metric": "Calmar", # Added scenario-level metric
         "optimize": [
             {
                 "parameter": "num_holdings",
-                "metric": "Calmar",
                 "min_value": 10,
                 "max_value": 30,
                 "step": 1
             },
             {
                 "parameter": "rolling_window",
-                "metric": "Calmar",
                 "min_value": 1,
                 "max_value": 6,
                 "step": 1
@@ -340,24 +330,22 @@ BACKTEST_SCENARIOS = [
         "transaction_costs_bps": 10,
         "train_window_months": 24,
         "test_window_months": 12,
+        "optimization_metric": "Sharpe", # Added scenario-level metric
         "optimize": [
             {
                 "parameter": "num_holdings",
-                "metric": "Sharpe",
                 "min_value": 10,
                 "max_value": 30,
                 "step": 1
             },
             {
                 "parameter": "rolling_window",
-                "metric": "Sharpe",
                 "min_value": 1,
                 "max_value": 6,
                 "step": 1
             },
             {
                 "parameter": "sizer_sharpe_window",
-                "metric": "Sharpe",
                 "min_value": 2,
                 "max_value": 12,
                 "step": 1
@@ -504,18 +492,28 @@ def populate_default_optimizations():
     for scen in BACKTEST_SCENARIOS:
         if "optimize" not in scen:
             scen["optimize"] = []
-        existing = {opt["parameter"] for opt in scen["optimize"]}
+
+        # Ensure optimization_metric is present if optimize section exists
+        if "optimize" in scen and "optimization_metric" not in scen:
+            # Default to "Calmar" or another suitable default if not inferable
+            # For now, this logic assumes it's added manually or by a previous step
+            # If we need to infer it, we'd look at the first param's old metric
+            pass # We expect optimization_metric to be set by the refactoring
+
+        existing_params = {opt["parameter"] for opt in scen["optimize"]}
 
         strat_cls = _resolve_strategy(scen["strategy"])
         if strat_cls is not None:
             for param in strat_cls.tunable_parameters():
-                if param not in existing:
+                if param not in existing_params:
+                    # Add parameter without metric, as metric is scenario-level
                     scen["optimize"].append({"parameter": param})
 
         position_sizer_name = scen.get("position_sizer")
         if position_sizer_name:
             sizer_param = sizer_param_map.get(position_sizer_name)
-            if sizer_param and sizer_param not in existing:
+            if sizer_param and sizer_param not in existing_params:
+                # Add sizer parameter without metric
                 scen["optimize"].append({"parameter": sizer_param})
 
 

--- a/src/portfolio_backtester/optimization/optuna_objective.py
+++ b/src/portfolio_backtester/optimization/optuna_objective.py
@@ -15,7 +15,7 @@ def build_objective(
     train_rets_daily,
     bench_series_daily,
     features_slice,
-    metric: str = "Calmar",
+    # metric: str = "Calmar", # Metric is now part of base_scen_cfg
 ):
     """
     Factory to build a customized Optuna objective function.
@@ -24,6 +24,8 @@ def build_objective(
 
     # Extract optimization specifications from base_scen_cfg
     optimization_specs = base_scen_cfg.get("optimize", [])
+    # Get the optimization metric from the scenario configuration
+    metric_to_optimize = base_scen_cfg.get("optimization_metric", "Calmar") # Default to Calmar if not specified
 
     def objective(trial: optuna.trial.Trial) -> float:
         # 1 ─ suggest parameters ----------------------------------------
@@ -64,7 +66,7 @@ def build_objective(
         bench_rets_daily = bench_series_daily.pct_change(fill_method=None).fillna(0)
 
         val = calculate_metrics(
-            rets, bench_rets_daily, g_cfg["benchmark"])[metric]
+            rets, bench_rets_daily, g_cfg["benchmark"])[metric_to_optimize]
 
         # Penalise invalid metrics with negative infinity (since we maximise)
         if pd.isna(val) or not np.isfinite(val):

--- a/src/portfolio_backtester/strategies/momentum_strategy.py
+++ b/src/portfolio_backtester/strategies/momentum_strategy.py
@@ -20,9 +20,30 @@ class MomentumStrategy(BaseStrategy):
 
     @classmethod
     def get_required_features(cls, strategy_config: dict) -> Set[Feature]:
-        features: Set[Feature] = {Momentum(lookback_months=strategy_config["lookback_months"])}
-        if strategy_config.get("sma_filter_window") is not None:
-            features.add(BenchmarkSMA(sma_filter_window=strategy_config["sma_filter_window"]))
+        # Get the actual strategy parameters, falling back to strategy_config if 'strategy_params' is not present
+        params = strategy_config.get("strategy_params", strategy_config)
+
+        # Ensure 'lookback_months' is present in params, otherwise use a default from __init__ or handle error
+        # For now, we assume it's present as per typical scenario structure.
+        # If this method is called with a raw strategy_config (not a full scenario dict),
+        # 'lookback_months' should be directly in it.
+        lookback = params.get("lookback_months")
+        if lookback is None:
+            # This might happen if called with a config that's not a full scenario
+            # and doesn't directly contain 'lookback_months'.
+            # Consider accessing self.strategy_config if this were an instance method,
+            # or ensure callers always provide it.
+            # For a classmethod, the input dict is all we have.
+            # Fallback to a default or raise a more specific error.
+            # The __init__ sets a default, but that's not accessible here directly.
+            # Let's assume 'lookback_months' must be resolvable from 'params'.
+            raise KeyError("'lookback_months' not found in strategy parameters. Ensure it is defined in 'strategy_params' or directly in the passed config.")
+
+        features: Set[Feature] = {Momentum(lookback_months=lookback)}
+
+        sma_filter = params.get("sma_filter_window")
+        if sma_filter is not None:
+            features.add(BenchmarkSMA(sma_filter_window=sma_filter))
         return features
 
     def __init__(self, strategy_config):

--- a/tests/optimization/test_optuna_objective.py
+++ b/tests/optimization/test_optuna_objective.py
@@ -4,11 +4,14 @@ from src.portfolio_backtester.optimization.optuna_objective import build_objecti
 
 def test_build_objective_with_config():
     g_cfg = {"benchmark": "SPY"}
-    base_scen_cfg = {"strategy_params": {"max_lookback": 50, "leverage": 1.0},
-                     "optimize": [
-                         {"parameter": "max_lookback"},
-                         {"parameter": "leverage"}
-                     ]}
+    base_scen_cfg = {
+        "strategy_params": {"max_lookback": 50, "leverage": 1.0},
+        "optimization_metric": "Sharpe",  # New scenario-level metric
+        "optimize": [
+            {"parameter": "max_lookback"},
+            {"parameter": "leverage"}
+        ]
+    }
     train_data_monthly = MagicMock()
     train_data_daily = MagicMock()
     train_rets_daily = MagicMock()
@@ -22,14 +25,40 @@ def test_build_objective_with_config():
         train_data_daily,
         train_rets_daily,
         bench_series_daily,
-        features_slice,
+        features_slice
+        # metric argument removed
     )
 
     trial = MagicMock()
-    with patch('src.portfolio_backtester.optimization.optuna_objective._run_scenario_static', return_value=MagicMock()), \
-         patch('src.portfolio_backtester.optimization.optuna_objective.calculate_metrics', return_value={"Calmar": 1.0}):
-        
-        objective_fn(trial)
+    mock_calculate_metrics = MagicMock(return_value={"Sharpe": 1.0, "Calmar": 0.5}) # Ensure it contains the target metric
 
-    trial.suggest_int.assert_called_with("max_lookback", 20, 252, step=10)
-    trial.suggest_float.assert_called_with("leverage", 0.5, 2.0, step=0.1, log=False)
+    with patch('src.portfolio_backtester.optimization.optuna_objective._run_scenario_static', return_value=MagicMock()), \
+         patch('src.portfolio_backtester.optimization.optuna_objective.calculate_metrics', mock_calculate_metrics):
+        
+        result = objective_fn(trial)
+
+    trial.suggest_int.assert_called_with("max_lookback", 20, 252, step=10) # These defaults come from OPTIMIZER_PARAMETER_DEFAULTS
+    trial.suggest_float.assert_called_with("leverage", 0.5, 2.0, step=0.1, log=False) # These defaults come from OPTIMIZER_PARAMETER_DEFAULTS
+
+    # Assert that calculate_metrics was called and the value for "Sharpe" (from base_scen_cfg) was returned
+    mock_calculate_metrics.assert_called_once()
+    assert result == 1.0
+
+    # Test with a different metric to be sure
+    base_scen_cfg["optimization_metric"] = "Calmar"
+    objective_fn_calmar = build_objective(
+        g_cfg,
+        base_scen_cfg,
+        train_data_monthly,
+        train_data_daily,
+        train_rets_daily,
+        bench_series_daily,
+        features_slice
+    )
+    with patch('src.portfolio_backtester.optimization.optuna_objective._run_scenario_static', return_value=MagicMock()), \
+         patch('src.portfolio_backtester.optimization.optuna_objective.calculate_metrics', mock_calculate_metrics):
+        mock_calculate_metrics.reset_mock() # Reset mock for the second call
+        result_calmar = objective_fn_calmar(trial)
+
+    mock_calculate_metrics.assert_called_once()
+    assert result_calmar == 0.5

--- a/tests/test_backtester.py
+++ b/tests/test_backtester.py
@@ -28,10 +28,11 @@ class TestBacktester(unittest.TestCase):
                 "transaction_costs_bps": 10,
                 "train_window_months": 24,
                 "test_window_months": 6,
+                "optimization_metric": "Sharpe", # Added scenario-level metric
                 "optimize": [
                     {
                         "parameter": "lookback_months",
-                        "metric": "Sharpe",
+                        # "metric": "Sharpe", # Metric removed from here
                         "min_value": 3,
                         "max_value": 9,
                         "step": 3


### PR DESCRIPTION
- Modified `config.py` to define a single `optimization_metric` per backtest scenario, removing per-parameter metrics.
- Updated `optimization/optuna_objective.py` to use this scenario-level metric.
- Adjusted `backtester.py` to align with the changes in `optuna_objective.py`.
- Corrected parameter access in `strategies/momentum_strategy.py`'s `get_required_features` method.
- Updated relevant tests in `tests/optimization/test_optuna_objective.py` and `tests/test_backtester.py` to reflect the new configuration and ensure correctness.