### PR TITLE
feat: Implement multi-target optimization

### DIFF
--- a/src/portfolio_backtester/config.py
+++ b/src/portfolio_backtester/config.py
@@ -13,7 +13,12 @@ BACKTEST_SCENARIOS = [
         "transaction_costs_bps": 10,
         "train_window_months": 60,
         "test_window_months": 24,
-        "optimization_metric": "Sortino", # Added scenario-level metric
+        # Example of new multi-objective optimization
+        "optimization_targets": [
+            {"name": "Sortino", "direction": "maximize"},
+            {"name": "Max Drawdown", "direction": "minimize"}
+        ],
+        # "optimization_metric": "Sortino", # Replaced by optimization_targets
         "optimize": [
             {"parameter": "num_holdings", "min_value": 10, "max_value": 35, "step": 1},
             {"parameter": "top_decile_fraction", "min_value": 0.05, "max_value": 0.3, "step": 0.01},

--- a/tests/optimization/test_optuna_objective.py
+++ b/tests/optimization/test_optuna_objective.py
@@ -1,64 +1,152 @@
 import pytest
+import numpy as np
 from unittest.mock import MagicMock, patch
 from src.portfolio_backtester.optimization.optuna_objective import build_objective
 
-def test_build_objective_with_config():
+# Common setup for tests
+@pytest.fixture
+def common_mocks():
     g_cfg = {"benchmark": "SPY"}
-    base_scen_cfg = {
-        "strategy_params": {"max_lookback": 50, "leverage": 1.0},
-        "optimization_metric": "Sharpe",  # New scenario-level metric
-        "optimize": [
-            {"parameter": "max_lookback"},
-            {"parameter": "leverage"}
-        ]
-    }
     train_data_monthly = MagicMock()
     train_data_daily = MagicMock()
     train_rets_daily = MagicMock()
     bench_series_daily = MagicMock()
     features_slice = MagicMock()
+    trial = MagicMock()
+    return g_cfg, train_data_monthly, train_data_daily, train_rets_daily, bench_series_daily, features_slice, trial
+
+def test_build_objective_single_metric(common_mocks):
+    g_cfg, train_data_monthly, train_data_daily, train_rets_daily, bench_series_daily, features_slice, trial = common_mocks
+
+    base_scen_cfg = {
+        "strategy_params": {"max_lookback": 50, "leverage": 1.0},
+        "optimization_metric": "Sharpe",
+        "optimize": [
+            {"parameter": "max_lookback"},
+            {"parameter": "leverage"}
+        ]
+    }
 
     objective_fn = build_objective(
-        g_cfg,
-        base_scen_cfg,
-        train_data_monthly,
-        train_data_daily,
-        train_rets_daily,
-        bench_series_daily,
-        features_slice
-        # metric argument removed
+        g_cfg, base_scen_cfg, train_data_monthly, train_data_daily,
+        train_rets_daily, bench_series_daily, features_slice
     )
 
-    trial = MagicMock()
-    mock_calculate_metrics = MagicMock(return_value={"Sharpe": 1.0, "Calmar": 0.5}) # Ensure it contains the target metric
+    mock_metrics_result = {"Sharpe": 1.5, "Calmar": 0.8}
+    mock_calculate_metrics = MagicMock(return_value=mock_metrics_result)
 
     with patch('src.portfolio_backtester.optimization.optuna_objective._run_scenario_static', return_value=MagicMock()), \
          patch('src.portfolio_backtester.optimization.optuna_objective.calculate_metrics', mock_calculate_metrics):
-        
         result = objective_fn(trial)
 
-    trial.suggest_int.assert_called_with("max_lookback", 20, 252, step=10) # These defaults come from OPTIMIZER_PARAMETER_DEFAULTS
-    trial.suggest_float.assert_called_with("leverage", 0.5, 2.0, step=0.1, log=False) # These defaults come from OPTIMIZER_PARAMETER_DEFAULTS
-
-    # Assert that calculate_metrics was called and the value for "Sharpe" (from base_scen_cfg) was returned
+    trial.suggest_int.assert_called_with("max_lookback", 20, 252, step=10)
+    trial.suggest_float.assert_called_with("leverage", 0.5, 2.0, step=0.1, log=False)
     mock_calculate_metrics.assert_called_once()
-    assert result == 1.0
+    assert result == 1.5
 
-    # Test with a different metric to be sure
-    base_scen_cfg["optimization_metric"] = "Calmar"
-    objective_fn_calmar = build_objective(
-        g_cfg,
-        base_scen_cfg,
-        train_data_monthly,
-        train_data_daily,
-        train_rets_daily,
-        bench_series_daily,
-        features_slice
-    )
+def test_build_objective_multi_metric(common_mocks):
+    g_cfg, train_data_monthly, train_data_daily, train_rets_daily, bench_series_daily, features_slice, trial = common_mocks
+
+    base_scen_cfg = {
+        "strategy_params": {"param1": 10},
+        "optimization_targets": [
+            {"name": "Total Return", "direction": "maximize"},
+            {"name": "Max Drawdown", "direction": "minimize"}
+        ],
+        "optimize": [{"parameter": "param1"}] # Assuming param1 is in OPTIMIZER_PARAMETER_DEFAULTS
+    }
+    # Mock OPTIMIZER_PARAMETER_DEFAULTS for "param1" if not already present
+    with patch('src.portfolio_backtester.optimization.optuna_objective.OPTIMIZER_PARAMETER_DEFAULTS', {"param1": {"type": "int", "low": 1, "high": 20, "step": 1}}):
+        objective_fn = build_objective(
+            g_cfg, base_scen_cfg, train_data_monthly, train_data_daily,
+            train_rets_daily, bench_series_daily, features_slice
+        )
+
+    mock_metrics_result = {"Total Return": 0.25, "Max Drawdown": -0.1, "Sharpe": 1.2}
+    mock_calculate_metrics = MagicMock(return_value=mock_metrics_result)
+
     with patch('src.portfolio_backtester.optimization.optuna_objective._run_scenario_static', return_value=MagicMock()), \
          patch('src.portfolio_backtester.optimization.optuna_objective.calculate_metrics', mock_calculate_metrics):
-        mock_calculate_metrics.reset_mock() # Reset mock for the second call
-        result_calmar = objective_fn_calmar(trial)
+        result = objective_fn(trial)
+
+    trial.suggest_int.assert_called_with("param1", 1, 20, step=1)
+    mock_calculate_metrics.assert_called_once()
+    assert isinstance(result, tuple)
+    assert result == (0.25, -0.1)
+
+def test_build_objective_default_metric_when_none_specified(common_mocks):
+    g_cfg, train_data_monthly, train_data_daily, train_rets_daily, bench_series_daily, features_slice, trial = common_mocks
+
+    base_scen_cfg = { # No optimization_metric or optimization_targets
+        "strategy_params": {"leverage": 1.0},
+        "optimize": [{"parameter": "leverage"}]
+    }
+
+    objective_fn = build_objective(
+        g_cfg, base_scen_cfg, train_data_monthly, train_data_daily,
+        train_rets_daily, bench_series_daily, features_slice
+    )
+
+    mock_metrics_result = {"Calmar": 0.7, "Sharpe": 1.1} # Must contain default "Calmar"
+    mock_calculate_metrics = MagicMock(return_value=mock_metrics_result)
+
+    with patch('src.portfolio_backtester.optimization.optuna_objective._run_scenario_static', return_value=MagicMock()), \
+         patch('src.portfolio_backtester.optimization.optuna_objective.calculate_metrics', mock_calculate_metrics):
+        result = objective_fn(trial)
 
     mock_calculate_metrics.assert_called_once()
-    assert result_calmar == 0.5
+    assert result == 0.7 # Should default to Calmar
+
+def test_build_objective_single_metric_invalid_value(common_mocks):
+    g_cfg, train_data_monthly, train_data_daily, train_rets_daily, bench_series_daily, features_slice, trial = common_mocks
+
+    base_scen_cfg = {"optimization_metric": "Sharpe", "strategy_params": {}, "optimize": []}
+    objective_fn = build_objective(
+        g_cfg, base_scen_cfg, train_data_monthly, train_data_daily,
+        train_rets_daily, bench_series_daily, features_slice
+    )
+
+    mock_metrics_result = {"Sharpe": np.nan}
+    mock_calculate_metrics = MagicMock(return_value=mock_metrics_result)
+
+    with patch('src.portfolio_backtester.optimization.optuna_objective._run_scenario_static', return_value=MagicMock()), \
+         patch('src.portfolio_backtester.optimization.optuna_objective.calculate_metrics', mock_calculate_metrics):
+        result = objective_fn(trial)
+    assert result == float("-inf")
+
+    mock_metrics_result_inf = {"Sharpe": np.inf}
+    mock_calculate_metrics_inf = MagicMock(return_value=mock_metrics_result_inf)
+    with patch('src.portfolio_backtester.optimization.optuna_objective._run_scenario_static', return_value=MagicMock()), \
+         patch('src.portfolio_backtester.optimization.optuna_objective.calculate_metrics', mock_calculate_metrics_inf):
+        result_inf = objective_fn(trial)
+    assert result_inf == float("-inf")
+
+
+def test_build_objective_multi_metric_invalid_values(common_mocks):
+    g_cfg, train_data_monthly, train_data_daily, train_rets_daily, bench_series_daily, features_slice, trial = common_mocks
+
+    base_scen_cfg = {
+        "optimization_targets": [
+            {"name": "Total Return", "direction": "maximize"},
+            {"name": "Max Drawdown", "direction": "minimize"},
+            {"name": "Sharpe", "direction": "maximize"}
+        ],
+        "strategy_params": {}, "optimize": []
+    }
+    objective_fn = build_objective(
+        g_cfg, base_scen_cfg, train_data_monthly, train_data_daily,
+        train_rets_daily, bench_series_daily, features_slice
+    )
+
+    mock_metrics_result = {"Total Return": np.nan, "Max Drawdown": 0.1, "Sharpe": np.inf}
+    mock_calculate_metrics = MagicMock(return_value=mock_metrics_result)
+
+    with patch('src.portfolio_backtester.optimization.optuna_objective._run_scenario_static', return_value=MagicMock()), \
+         patch('src.portfolio_backtester.optimization.optuna_objective.calculate_metrics', mock_calculate_metrics):
+        result = objective_fn(trial)
+
+    assert isinstance(result, tuple)
+    assert len(result) == 3
+    assert np.isnan(result[0]) # Total Return was np.nan
+    assert result[1] == 0.1     # Max Drawdown was valid
+    assert np.isnan(result[2]) # Sharpe was np.inf, should be nan for multi-obj


### PR DESCRIPTION
This commit introduces multi-target optimization capabilities to the backtester using Optuna.

Key changes:
- Modified `config.py` to support a new `optimization_targets` key in scenario definitions. This allows specifying multiple metrics and their optimization directions (e.g., maximize profit, minimize drawdown).
- Updated `optimization/optuna_objective.py` to handle the new `optimization_targets` configuration. The `build_objective` function now constructs an objective that returns a tuple of results for multi-target optimization, or a single value for single-target optimization. It also handles fallback to the old `optimization_metric` for backward compatibility.
- Adjusted the Optuna study creation logic in `backtester.py` to correctly pass `direction` (for single-objective) or `directions` (for multi-objective) to `optuna.create_study`.
- Added and updated unit tests in `tests/optimization/test_optuna_objective.py` to cover various scenarios, including single-objective, multi-objective, default metric fallbacks, and handling of invalid metric values.
- Ensured all relevant existing tests pass after these changes.