### PR TITLE
Fix: Update pyproject.toml with correct dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,10 +31,16 @@ dependencies = [
     "openpyxl",
     "xlrd==2.0.1",
     "pyarrow",
-    "radon",
-    "xenon",
     "optuna>=4.4",
     "pandas-datareader"
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "coverage",
+    "radon",
+    "xenon"
 ]
 
 [project.urls]


### PR DESCRIPTION
Separated production and development dependencies. Added missing dev dependencies: pytest, coverage.
Moved radon and xenon to dev dependencies.