### PR TITLE
Fix: Address unrealistic returns from DVOL sizer and improve stability

### DIFF
--- a/config/parameters.yaml
+++ b/config/parameters.yaml
@@ -144,7 +144,7 @@ OPTIMIZER_PARAMETER_DEFAULTS:
     step: 1
   sizer_dvol_window:
     type: "int"
-    low: 2
+    low: 6
     high: 12
     step: 1
   long_only:

--- a/src/portfolio_backtester/backtester.py
+++ b/src/portfolio_backtester/backtester.py
@@ -111,7 +111,7 @@ class Backtester:
             logger.info(f"Running scenario: {scenario_config['name']}")
 
         if rets_daily is None:
-            rets_daily = price_data_daily.pct_change().fillna(0)
+            rets_daily = price_data_daily.pct_change(fill_method=None).fillna(0)
         
         strategy = self._get_strategy(
             scenario_config["strategy"], scenario_config["strategy_params"]
@@ -236,6 +236,7 @@ class Backtester:
             "sharpe_momentum": strategies.SharpeMomentumStrategy,
             "sortino_momentum": strategies.SortinoMomentumStrategy,
             "vams_momentum": strategies.VAMSMomentumStrategy,
+            "momentum_dvol_sizer": strategies.MomentumDvolSizerStrategy, # Added this line
         }
         
         required_features = get_required_features_from_scenarios(self.scenarios, strategy_registry)
@@ -250,7 +251,7 @@ class Backtester:
         logger.info("All features pre-computed.")
 
         # Daily return series used for portfolio P&L
-        rets_full = daily_data.pct_change().fillna(0)
+        rets_full = daily_data.pct_change(fill_method=None).fillna(0)
 
         if self.args.mode == "optimize":
             self._run_optimize_mode(self.scenarios[0], monthly_data, daily_data, rets_full)  # pass both data sets


### PR DESCRIPTION
The rolling_downside_volatility_sizer was producing unrealistic returns and NaN errors, particularly when the optimization process selected very short sizer_dvol_window values (e.g., 2 months).

This commit implements the following fixes:
- Modified `rolling_downside_volatility_sizer`:
    - Introduced an epsilon to the downside volatility calculation to prevent division by zero and stabilize factors from very small volatilities.
    - Ensured robust handling of NaN/inf in sizing factors by converting them to zero, leading to zero weight for the affected asset/period.
    - Ensured final weights are zero if all factors for a period are zero, preventing NaN propagation in weights.
- Corrected `pct_change()` calls in `backtester.py` by adding `fill_method=None` to address a FutureWarning and ensure explicit behavior.
- Improved `YFinanceDataSource` to use `auto_adjust=True` for fetching adjusted prices, enhancing data accuracy.
- Adjusted the default optimization range for `sizer_dvol_window` in `config/parameters.yaml` (low increased from 2 to 6 months) to guide the optimizer towards more stable parameter choices.
- Fixed a bug in `backtester.py` where `MomentumDvolSizerStrategy` was missing from the `strategy_registry` used for feature collection, causing `KeyError` for features required by this strategy.
- Updated the unit test for `rolling_downside_volatility_sizer` to align with the new, more robust logic.

These changes result in more realistic backtest outputs for scenarios using the DVOL sizer and improve the overall stability and correctness of the backtesting framework.