### PR TITLE
feat: Implement configurable early stopping for optimizer

### DIFF
--- a/src/portfolio_backtester/config.py
+++ b/src/portfolio_backtester/config.py
@@ -35,7 +35,13 @@ BACKTEST_SCENARIOS = [
             # "volatility_targeting": {"name": "none"}
         },
         "mc_simulations": 1000,
-        "mc_years": 10
+        "mc_years": 10,
+        # Example of new early stopping configuration
+        "early_stopping_enabled": True,
+        "early_stopping_metric": "Sortino", # Monitored metric (can be one from optimization_targets)
+        "early_stopping_patience_trials": 30, # Stop after 30 trials with no improvement
+        "early_stopping_min_delta": 0.01,     # Minimum improvement in Sortino to be considered progress
+        "early_stopping_warmup_trials": 15     # Wait for 15 trials before applying early stopping
     },
     {
         "name": "Momentum_Vol_Targeted_10pct",


### PR DESCRIPTION
Adds a configurable early stopping mechanism to the Optuna optimization process. This feature allows stopping an optimization study for a given scenario if the monitored optimization metric does not show significant improvement over a defined number of trials, after an initial warmup period.

Key changes:
-   Scenario configurations in `config.py` can now include parameters:
    -   `early_stopping_enabled` (bool)
    -   `early_stopping_metric` (str, metric to watch)
    -   `early_stopping_patience_trials` (int)
    -   `early_stopping_min_delta` (float)
    -   `early_stopping_warmup_trials` (int)
-   The Optuna callback in `Backtester.run_optimization` is enhanced to
    incorporate this logic, checking the specified metric against its
    progress.
-   The existing early stopping based on consecutive zero-return trials
    (CLI controlled) is preserved.
-   Added unit tests for the early stopping callback logic.
-   Added an integration test to verify early stopping within the
    `Backtester.run_optimization` flow.
-   Updated `README.md` to document the new feature.