### PR TITLE
Fix: Disable signal smoothing for Momentum_Unfiltered scenario

### DIFF
--- a/config/scenarios.yaml
+++ b/config/scenarios.yaml
@@ -42,6 +42,7 @@ BACKTEST_SCENARIOS:
         step: 1
     strategy_params:
       long_only: True
+      smoothing_lambda: 1.0 # Disable EWMA signal smoothing
       sizer_dvol_window: 12 # Default value for downside volatility sizer window
       target_volatility: 0.10 # Default value for target volatility
     mc_simulations: 1000


### PR DESCRIPTION
The 'Momentum_Unfiltered' scenario exhibited extremely high returns due to the default EWMA smoothing of signals (smoothing_lambda=0.5) in combination with the EqualWeightSizer. This led to fractional signals that, when normalized, resulted in excessive portfolio concentration.

This commit disables signal smoothing for this specific scenario by setting `smoothing_lambda: 1.0` in its strategy_params. This will ensure that binary (0.0/1.0) signals are passed to the EqualWeightSizer, leading to more conventional position weighting and more realistic backtest performance.