### PR TITLE
Fix: Ensure all optimizable momentum features are pre-computed

### DIFF
--- a/config/parameters.yaml
+++ b/config/parameters.yaml
@@ -99,10 +99,38 @@ OPTIMIZER_PARAMETER_DEFAULTS:
     low: 0.0
     high: 0.1
     step: 0.01
-  lookback_months: # Temporarily changed to single categorical for testing sizer optimization
+  lookback_months: # Old parameter, can be kept for strategies not yet updated
     type: "categorical"
-    values: [6] # Fixed to 6 months, assuming 'momentum_6m' feature exists
-  alpha:
+    values: [6]
+  momentum_lookback_standard:
+    type: "int"
+    low: 6
+    high: 12
+    step: 1
+  momentum_skip_standard:
+    type: "int"
+    low: 1
+    high: 2
+    step: 1
+  momentum_lookback_predictive:
+    type: "int"
+    low: 6
+    high: 12
+    step: 1
+  momentum_skip_predictive:
+    type: "int"
+    low: 0
+    high: 1
+    step: 1
+  blending_lambda:
+    type: "float"
+    low: 0.0
+    high: 1.0
+    step: 0.1
+  apply_trading_lag:
+    type: "categorical"
+    values: [True, False]
+  alpha: # For DPVAMS
     type: "float"
     low: 0.1
     high: 0.9

--- a/src/portfolio_backtester/backtester.py
+++ b/src/portfolio_backtester/backtester.py
@@ -288,7 +288,8 @@ class Backtester:
             "sharpe_momentum": strategies.SharpeMomentumStrategy,
             "sortino_momentum": strategies.SortinoMomentumStrategy,
             "vams_momentum": strategies.VAMSMomentumStrategy,
-            "momentum_dvol_sizer": strategies.MomentumDvolSizerStrategy, # Added this line
+            "momentum_dvol_sizer": strategies.MomentumDvolSizerStrategy,
+            "filtered_lagged_momentum": strategies.FilteredLaggedMomentumStrategy, # Added
         }
         
         required_features = get_required_features_from_scenarios(self.scenarios, strategy_registry)

--- a/src/portfolio_backtester/feature.py
+++ b/src/portfolio_backtester/feature.py
@@ -88,20 +88,40 @@ class VAMS(Feature):
 
 
 class Momentum(Feature):
-    """Computes momentum for each asset."""
+    """Computes momentum for each asset: P(t-skip_months)/P(t-skip_months-lookback_months) - 1."""
 
-    def __init__(self, lookback_months: int):
-        super().__init__(lookback_months=lookback_months)
+    def __init__(self, lookback_months: int, skip_months: int = 0, name_suffix: str = ""):
+        super().__init__(lookback_months=lookback_months, skip_months=skip_months, name_suffix=name_suffix)
         self.lookback_months = lookback_months
+        self.skip_months = skip_months
+        self.name_suffix = name_suffix # e.g. "std" or "pred"
 
     @property
     def name(self) -> str:
-        return f"momentum_{self.lookback_months}m"
+        if self.skip_months == 0 and not self.name_suffix:
+            # Backward compatibility for simple momentum feature name
+            return f"momentum_{self.lookback_months}m"
+
+        base_name = f"momentum_{self.lookback_months}m_skip{self.skip_months}m"
+        if self.name_suffix: # Add underscore if suffix exists and suffix is not empty
+            return f"{base_name}_{self.name_suffix}"
+        return base_name
 
     def compute(self, data: pd.DataFrame, benchmark_data: pd.Series | None = None) -> pd.DataFrame:
-        rets = data.pct_change(fill_method=None).fillna(0)
-        momentum = (1 + rets).rolling(self.lookback_months).apply(np.prod, raw=True) - 1
-        return momentum
+        # Assuming data is monthly prices for feature computation.
+        monthly_rets = data.pct_change().fillna(0) # Use default pct_change, then fillna
+
+        # Rolling product of (1+monthly_return) to get P(t)/P(t-L) - 1
+        momentum_lookback_period = (1 + monthly_rets).rolling(
+            window=self.lookback_months,
+            min_periods=int(self.lookback_months * 0.9) # Ensure most of the window has data
+        ).apply(np.prod, raw=True) - 1
+
+        # Shift the result by skip_months.
+        # So, value at row 't' becomes P(t-skip_months)/P(t-skip_months-lookback_months) - 1
+        final_momentum = momentum_lookback_period.shift(self.skip_months)
+
+        return final_momentum
 
 
 class BenchmarkSMA(Feature):
@@ -200,103 +220,156 @@ class DPVAMS(Feature):
 
 
 from .config_loader import OPTIMIZER_PARAMETER_DEFAULTS
+from typing import Any # For type hinting
 
+# Helper function to extract a list of values for an optimizable parameter
+def _get_opt_values_for_param(
+    param_name: str,
+    scen_optimize_specs: list,
+    static_params: dict,
+    default_val: Any,
+    param_type_override: str | None = None
+) -> list:
+    opt_spec = next((s for s in scen_optimize_specs if s["parameter"] == param_name), None)
+
+    if opt_spec:
+        min_v = opt_spec.get("min_value")
+        max_v = opt_spec.get("max_value")
+        step = opt_spec.get("step")
+        values_categorical = opt_spec.get("values")
+
+        # Determine type: opt_spec -> default_param_config -> type of default_val -> param_type_override
+        default_param_config = OPTIMIZER_PARAMETER_DEFAULTS.get(param_name, {})
+        param_type = param_type_override or opt_spec.get("type", default_param_config.get("type"))
+
+        if param_type is None: # Infer from default_val if still None
+            if isinstance(default_val, bool): param_type = "categorical" # Treat bools as categorical [True, False]
+            elif isinstance(default_val, int): param_type = "int"
+            elif isinstance(default_val, float): param_type = "float"
+            else: param_type = "categorical" # Fallback for other types
+
+        if param_type == "categorical":
+            return values_categorical if values_categorical is not None else [static_params.get(param_name, default_val)]
+
+        # For numerical types, ensure min_v, max_v are present
+        if min_v is None: min_v = default_param_config.get("low", default_val)
+        if max_v is None: max_v = default_param_config.get("high", default_val)
+        if step is None: step = default_param_config.get("step", 1 if param_type == "int" else 0.1)
+
+
+        if param_type == "int":
+            return list(range(int(min_v), int(max_v) + int(step), int(step)))
+        elif param_type == "float":
+            # Use np.arange for float steps, ensuring endpoint is handled correctly
+            # Add a small epsilon to max_v to include it if max_v is a multiple of step
+            return [round(v, 4) for v in np.arange(float(min_v), float(max_v) + float(step) * 0.5, float(step))]
+        else: # Should not happen if type is inferred or specified
+            return [static_params.get(param_name, default_val)]
+
+    else: # Parameter not being optimized, return its static or default value
+        return [static_params.get(param_name, default_val)]
 
 def get_required_features_from_scenarios(strategy_configs: list, strategy_registry: dict) -> Set[Feature]:
     """
     Gathers all unique feature requirements from a list of strategy configurations.
     It considers both static strategy parameters and optimized parameters.
     """
-    required_features = set()
+    required_features: Set[Feature] = set()
     for scen in strategy_configs:
         strategy_name = scen.get("strategy")
         strategy_class = strategy_registry.get(strategy_name)
+
+        # Static features from strategy_params
         if strategy_class:
             required_features.update(strategy_class.get_required_features(scen))
 
-        # Also check for features needed for optimization
-        if "optimize" in scen:
-            for opt_spec in scen["optimize"]: # Renamed opt_param to opt_spec for clarity
-                param_name = opt_spec["parameter"]
-                default_param_config = OPTIMIZER_PARAMETER_DEFAULTS.get(param_name, {})
+        scen_optimize_specs = scen.get("optimize", [])
+        static_params = scen.get("strategy_params", scen) # Fallback to scen itself
 
-                # Determine type: opt_spec takes precedence over default_param_config
-                param_type = opt_spec.get("type", default_param_config.get("type"))
+        # Handle specific parameter combinations for FilteredLaggedMomentumStrategy if optimized
+        if strategy_name == "filtered_lagged_momentum":
+            # Check if any of its core momentum parameters are being optimized
+            is_flm_mom_params_opt = any(s["parameter"] in [
+                "momentum_lookback_standard", "momentum_skip_standard",
+                "momentum_lookback_predictive", "momentum_skip_predictive"
+            ] for s in scen_optimize_specs)
 
-                if param_name == "sma_filter_window":
-                    if param_type == "categorical":
-                        values = opt_spec.get("values", default_param_config.get("values", []))
-                        for window in values:
-                            if isinstance(window, int):
-                                required_features.add(BenchmarkSMA(sma_filter_window=window))
-                    elif param_type == "int":
-                        min_val = int(opt_spec.get("min_value", default_param_config.get("low", 2)))
-                        max_val = int(opt_spec.get("max_value", default_param_config.get("high", 24)))
-                        step = int(opt_spec.get("step", default_param_config.get("step", 1)))
-                        for window in range(min_val, max_val + 1, step):
-                            required_features.add(BenchmarkSMA(sma_filter_window=window))
+            if is_flm_mom_params_opt:
+                look_std_vals = _get_opt_values_for_param("momentum_lookback_standard", scen_optimize_specs, static_params, 11, "int")
+                skip_std_vals = _get_opt_values_for_param("momentum_skip_standard", scen_optimize_specs, static_params, 1, "int")
+                look_pred_vals = _get_opt_values_for_param("momentum_lookback_predictive", scen_optimize_specs, static_params, 11, "int")
+                skip_pred_vals = _get_opt_values_for_param("momentum_skip_predictive", scen_optimize_specs, static_params, 0, "int")
 
-                elif param_name == "lookback_months":
-                    lookback_values_to_add = set()
-                    if param_type == "categorical":
-                        values = opt_spec.get("values", default_param_config.get("values", []))
-                        for val in values:
-                            if isinstance(val, int):
-                                lookback_values_to_add.add(val)
-                    elif param_type == "int":
-                        min_val = int(opt_spec.get("min_value", default_param_config.get("low", 1)))
-                        max_val = int(opt_spec.get("max_value", default_param_config.get("high", 12)))
-                        step = int(opt_spec.get("step", default_param_config.get("step", 1)))
-                        for lookback in range(min_val, max_val + 1, step):
-                            lookback_values_to_add.add(lookback)
+                for l_std in look_std_vals:
+                    for s_std in skip_std_vals:
+                        required_features.add(Momentum(lookback_months=int(l_std), skip_months=int(s_std), name_suffix="std"))
+                for l_pred in look_pred_vals:
+                    for s_pred in skip_pred_vals:
+                        required_features.add(Momentum(lookback_months=int(l_pred), skip_months=int(s_pred), name_suffix="pred"))
 
-                    for lookback in lookback_values_to_add:
-                        required_features.add(Momentum(lookback_months=lookback))
-                        required_features.add(VAMS(lookback_months=lookback))
-                        # For DPVAMS, alpha is also needed. If alpha is optimized, this gets more complex.
-                        # Assuming a default or common alpha if not explicitly handled.
-                        # This part might need further refinement if alpha optimization is deeply tied here.
-                        # For now, using a common placeholder or relying on strategy_class.get_required_features
-                        # to handle DPVAMS based on static/optimized alpha.
-                        # Let's assume alpha is handled by the strategy's get_required_features or is static for this feature collection.
-                        # If 'alpha' is also in opt_spec, we might need to create combinations.
-                        # For simplicity, we'll stick to the original DPVAMS addition or assume strategy handles it.
-                        # A fixed common alpha for DPVAMS feature precomputation:
-                        fixed_alpha_for_dpvams_precomp = 0.5 # Or fetch from strategy_params if available
-                        alpha_param_config = OPTIMIZER_PARAMETER_DEFAULTS.get("alpha", {})
-                        alpha_values = scen.get("strategy_params",{}).get("alpha") # static alpha
+        # General loop for other optimizable parameters
+        for opt_spec in scen_optimize_specs:
+            param_name = opt_spec["parameter"]
 
-                        if isinstance(alpha_values, (int,float)): # static alpha
-                             required_features.add(DPVAMS(lookback_months=lookback, alpha=alpha_values))
-                        else: # alpha is optimized or not set, use placeholder or default
-                            # Check if alpha is optimized
-                            alpha_is_optimized = any(p["parameter"] == "alpha" for p in scen.get("optimize", []))
-                            if alpha_is_optimized:
-                                # If alpha is optimized, we'd ideally iterate its possible values too.
-                                # This creates a cartesian product of features, which can be large.
-                                # For now, let's add DPVAMS with a common alpha or skip if too complex here.
-                                # Sticking to simpler: add with a default alpha if alpha is optimized.
-                                # The strategy will ultimately pick the right one at runtime.
-                                alpha_opt_spec = next((s for s in scen["optimize"] if s["parameter"] == "alpha"), None)
-                                default_alpha_config = OPTIMIZER_PARAMETER_DEFAULTS.get("alpha", {})
-                                alpha_type = alpha_opt_spec.get("type", default_alpha_config.get("type")) if alpha_opt_spec else default_alpha_config.get("type")
+            # Skip if handled by the filtered_lagged_momentum block above
+            if strategy_name == "filtered_lagged_momentum" and param_name in [
+                "momentum_lookback_standard", "momentum_skip_standard",
+                "momentum_lookback_predictive", "momentum_skip_predictive"
+            ]:
+                continue
 
-                                if alpha_type == "categorical":
-                                    alpha_choices = alpha_opt_spec.get("values", default_alpha_config.get("values", [fixed_alpha_for_dpvams_precomp])) if alpha_opt_spec else default_alpha_config.get("values", [fixed_alpha_for_dpvams_precomp])
-                                    for a_val in alpha_choices: required_features.add(DPVAMS(lookback_months=lookback, alpha=float(a_val)))
-                                elif alpha_type == "float": # iterate through range
-                                    a_min = float(alpha_opt_spec.get("min_value", default_alpha_config.get("low", 0.1))) if alpha_opt_spec else float(default_alpha_config.get("low", 0.1))
-                                    a_max = float(alpha_opt_spec.get("max_value", default_alpha_config.get("high", 0.9))) if alpha_opt_spec else float(default_alpha_config.get("high", 0.9))
-                                    a_step = float(alpha_opt_spec.get("step", default_alpha_config.get("step", 0.1))) if alpha_opt_spec else float(default_alpha_config.get("step", 0.1))
-                                    current_a = a_min
-                                    while current_a <= a_max:
-                                        required_features.add(DPVAMS(lookback_months=lookback, alpha=round(current_a,4))) # round to avoid float issues
-                                        current_a += a_step
-                                else: # Default if alpha type is unknown or not optimized
-                                     required_features.add(DPVAMS(lookback_months=lookback, alpha=fixed_alpha_for_dpvams_precomp))
-                            else: # Alpha not optimized, use static from strategy_params or default
-                                static_alpha = scen.get("strategy_params",{}).get("alpha", fixed_alpha_for_dpvams_precomp)
-                                required_features.add(DPVAMS(lookback_months=lookback, alpha=float(static_alpha)))
+            default_param_config = OPTIMIZER_PARAMETER_DEFAULTS.get(param_name, {})
+            param_type = opt_spec.get("type", default_param_config.get("type"))
 
+            if param_name == "sma_filter_window":
+                default_val = static_params.get(param_name, 20) # Example default
+                sma_values = _get_opt_values_for_param(param_name, [opt_spec], static_params, default_val, param_type or "int")
+                for window in sma_values:
+                    required_features.add(BenchmarkSMA(sma_filter_window=int(window)))
 
+            elif param_name == "lookback_months": # For old MomentumStrategy, VAMS etc.
+                default_val = static_params.get(param_name, 6)
+                lookback_values = _get_opt_values_for_param(param_name, [opt_spec], static_params, default_val, param_type or "int")
+
+                for lookback in lookback_values:
+                    # Default Momentum (skip=0, no_suffix) for compatibility with MomentumSignalGenerator
+                    required_features.add(Momentum(lookback_months=int(lookback)))
+                    required_features.add(VAMS(lookback_months=int(lookback)))
+
+                    # DPVAMS: Needs alpha. Alpha can be static or optimized itself.
+                    alpha_default = 0.5
+                    alpha_values = _get_opt_values_for_param("alpha", scen_optimize_specs, static_params, alpha_default, "float")
+                    for alpha_val in alpha_values:
+                        required_features.add(DPVAMS(lookback_months=int(lookback), alpha=float(alpha_val)))
+
+            elif param_name == "alpha": # For DPVAMS, when alpha is optimized directly
+                # This is coupled with lookback_months. If lookback_months is also optimized,
+                # this block will correctly iterate alphas for each static/optimized lookback.
+                default_val = static_params.get(param_name, 0.5)
+                alpha_values = _get_opt_values_for_param(param_name, [opt_spec], static_params, default_val, param_type or "float")
+
+                # Get lookback_months values (optimized or static)
+                lookback_default = static_params.get("lookback_months",6) # Default if not optimizing lookback
+                lookback_values_for_alpha_opt = _get_opt_values_for_param("lookback_months", scen_optimize_specs, static_params, lookback_default, "int")
+
+                for lookback in lookback_values_for_alpha_opt:
+                    for alpha_val in alpha_values:
+                        required_features.add(DPVAMS(lookback_months=int(lookback), alpha=float(alpha_val)))
+
+            # Other optimizable params like 'rolling_window' for Sharpe, Sortino, Calmar
+            elif param_name == "rolling_window":
+                default_val = static_params.get(param_name, 6)
+                rw_values = _get_opt_values_for_param(param_name, [opt_spec], static_params, default_val, param_type or "int")
+                # Need to know which strategy this rolling_window is for to create the right feature
+                if strategy_class: # Check if strategy_class is resolved
+                    if hasattr(strategy_class, 'signal_generator_class'):
+                        gen_class_name = strategy_class.signal_generator_class.__name__
+                        for rw in rw_values:
+                            if gen_class_name == "SharpeSignalGenerator":
+                                required_features.add(SharpeRatio(rolling_window=int(rw)))
+                            elif gen_class_name == "SortinoSignalGenerator":
+                                target_ret = static_params.get("target_return", 0.0) # Get static target_return
+                                required_features.add(SortinoRatio(rolling_window=int(rw), target_return=float(target_ret)))
+                            elif gen_class_name == "CalmarSignalGenerator":
+                                required_features.add(CalmarRatio(rolling_window=int(rw)))
     return required_features

--- a/src/portfolio_backtester/signal_generators.py
+++ b/src/portfolio_backtester/signal_generators.py
@@ -219,3 +219,117 @@ __all__ = [
     "VAMSSignalGenerator",
     "DPVAMSSignalGenerator",
 ]
+
+
+class FilteredBlendedMomentumSignalGenerator(BaseSignalGenerator):
+    """
+    Signal generator for momentum strategy with dynamic candidate filtering
+    and blended ranking based on Calluzzo, Moneta & Topaloglu (2025).
+    """
+
+    def __init__(self, config: dict):
+        super().__init__(config)
+        # Parameters are expected in config["strategy_params"]
+        # e.g., momentum_lookback_standard, momentum_skip_standard
+        #       momentum_lookback_predictive, momentum_skip_predictive
+        #       blending_lambda, decile_fraction
+
+        # Suffixes are stored for consistent feature retrieval
+        self.std_mom_suffix = "std"
+        self.pred_mom_suffix = "pred"
+
+
+    def required_features(self) -> Set[Feature]:
+        features: Set[Feature] = set()
+        params = self._params()
+
+        std_lookback = params.get("momentum_lookback_standard", 11)
+        std_skip = params.get("momentum_skip_standard", 1)
+        pred_lookback = params.get("momentum_lookback_predictive", 11)
+        pred_skip = params.get("momentum_skip_predictive", 0)
+
+        features.add(Momentum(lookback_months=std_lookback, skip_months=std_skip, name_suffix=self.std_mom_suffix))
+        features.add(Momentum(lookback_months=pred_lookback, skip_months=pred_skip, name_suffix=self.pred_mom_suffix))
+
+        return features
+
+    def scores(self, features: dict) -> pd.DataFrame:
+        params = self._params()
+
+        std_lookback = params.get("momentum_lookback_standard", 11)
+        std_skip = params.get("momentum_skip_standard", 1)
+        pred_lookback = params.get("momentum_lookback_predictive", 11)
+        pred_skip = params.get("momentum_skip_predictive", 0)
+
+        blending_lambda = params.get("blending_lambda", 0.5)
+        top_decile_fraction = params.get("top_decile_fraction", 0.1) # Changed from decile_fraction
+
+        std_mom_name = f"momentum_{std_lookback}m_skip{std_skip}m_{self.std_mom_suffix}"
+        pred_mom_name = f"momentum_{pred_lookback}m_skip{pred_skip}m_{self.pred_mom_suffix}"
+
+        mom_std = features[std_mom_name]
+        mom_pred = features[pred_mom_name]
+
+        # Align dataframes by date index first
+        aligned_idx = mom_std.index.intersection(mom_pred.index)
+        mom_std = mom_std.loc[aligned_idx]
+        mom_pred = mom_pred.loc[aligned_idx]
+
+        final_scores = pd.DataFrame(np.nan, index=mom_std.index, columns=mom_std.columns)
+
+        for date in mom_std.index:
+            std_series_at_date = mom_std.loc[date].dropna()
+            pred_series_at_date = mom_pred.loc[date].dropna()
+
+            if std_series_at_date.empty or pred_series_at_date.empty:
+                continue
+
+            common_assets = std_series_at_date.index.intersection(pred_series_at_date.index)
+            if common_assets.empty:
+                continue
+
+            std_mom_values = std_series_at_date[common_assets]
+            pred_mom_values = pred_series_at_date[common_assets]
+
+            num_assets = len(common_assets)
+            n_decile = max(1, int(np.floor(num_assets * top_decile_fraction))) # Changed from decile_fraction
+
+            current_winners_idx = std_mom_values.nlargest(n_decile).index
+            current_losers_idx = std_mom_values.nsmallest(n_decile).index
+
+            predicted_winners_next_month_idx = pred_mom_values.nlargest(n_decile).index
+            predicted_losers_next_month_idx = pred_mom_values.nsmallest(n_decile).index
+
+            surviving_winners = current_winners_idx.intersection(predicted_winners_next_month_idx)
+            surviving_losers = current_losers_idx.intersection(predicted_losers_next_month_idx)
+
+            survivors_idx = surviving_winners.union(surviving_losers)
+
+            if survivors_idx.empty:
+                continue
+
+            std_mom_survivors = std_mom_values.loc[survivors_idx]
+            pred_mom_survivors = pred_mom_values.loc[survivors_idx]
+
+            # Percentile ranks (0 to 1), higher value = higher rank
+            rank_std_survivors = std_mom_survivors.rank(pct=True)
+            rank_pred_survivors = pred_mom_survivors.rank(pct=True)
+
+            blended_rank_survivors = (blending_lambda * rank_std_survivors +
+                                     (1 - blending_lambda) * rank_pred_survivors)
+
+            final_scores.loc[date, blended_rank_survivors.index] = blended_rank_survivors
+
+        return final_scores
+
+
+__all__ = [
+    "BaseSignalGenerator",
+    "MomentumSignalGenerator",
+    "SharpeSignalGenerator",
+    "SortinoSignalGenerator",
+    "CalmarSignalGenerator",
+    "VAMSSignalGenerator",
+    "DPVAMSSignalGenerator",
+    "FilteredBlendedMomentumSignalGenerator", # Added here
+]

--- a/src/portfolio_backtester/strategies/__init__.py
+++ b/src/portfolio_backtester/strategies/__init__.py
@@ -6,6 +6,7 @@ from .sortino_momentum_strategy import SortinoMomentumStrategy
 from .calmar_momentum_strategy import CalmarMomentumStrategy
 from .vams_no_downside_strategy import VAMSNoDownsideStrategy
 from .momentum_dvol_sizer_strategy import MomentumDvolSizerStrategy
+from .filtered_lagged_momentum_strategy import FilteredLaggedMomentumStrategy # Added
 
 __all__ = [
     "BaseStrategy",
@@ -16,4 +17,5 @@ __all__ = [
     "CalmarMomentumStrategy",
     "VAMSNoDownsideStrategy",
     "MomentumDvolSizerStrategy",
+    "FilteredLaggedMomentumStrategy", # Added
 ]

--- a/src/portfolio_backtester/strategies/calmar_momentum_strategy.py
+++ b/src/portfolio_backtester/strategies/calmar_momentum_strategy.py
@@ -1,4 +1,5 @@
 from typing import Set
+import pandas as pd # Added
 
 from .base_strategy import BaseStrategy
 from ..signal_generators import CalmarSignalGenerator
@@ -11,7 +12,41 @@ class CalmarMomentumStrategy(BaseStrategy):
 
     @classmethod
     def tunable_parameters(cls) -> set[str]:
-        return {"num_holdings", "rolling_window", "sma_filter_window"}
+        return {"num_holdings", "rolling_window", "sma_filter_window", "apply_trading_lag"} # Added
 
-    
+    def __init__(self, strategy_config: dict):
+        # Ensure 'apply_trading_lag' and other relevant params have defaults
+        # Assuming other defaults like 'rolling_window' are handled by BaseStrategy
+        # or expected to be in strategy_config.
+        # For CalmarSignalGenerator, 'rolling_window' is primary.
+        # BaseStrategy handles 'num_holdings', 'top_decile_fraction', 'smoothing_lambda', etc.
+
+        params_dict_to_update = strategy_config
+        if "strategy_params" in strategy_config:
+            if strategy_config["strategy_params"] is None:
+                 strategy_config["strategy_params"] = {}
+            params_dict_to_update = strategy_config["strategy_params"]
+
+        params_dict_to_update.setdefault("apply_trading_lag", False)
+        # Other CalmarMomentumStrategy specific defaults could be added here if any.
+        # For example, if 'rolling_window' for Calmar needs a default here:
+        params_dict_to_update.setdefault("rolling_window", 6) # Default if not provided
+
+        self.strategy_config = strategy_config
+        super().__init__(strategy_config)
+
+    def generate_signals(
+        self,
+        prices: pd.DataFrame, # Added import pandas as pd for this
+        features: dict,
+        benchmark_data: pd.Series, # Added import pandas as pd for this
+    ) -> pd.DataFrame:
+        """
+        Generates trading signals. Applies a one-month trading lag if configured.
+        """
+        weights = super().generate_signals(prices, features, benchmark_data)
+
+        if self.strategy_config.get("apply_trading_lag", False):
+            return weights.shift(1)
+        return weights
 

--- a/src/portfolio_backtester/strategies/filtered_lagged_momentum_strategy.py
+++ b/src/portfolio_backtester/strategies/filtered_lagged_momentum_strategy.py
@@ -1,0 +1,77 @@
+from typing import Set
+import pandas as pd
+
+from .base_strategy import BaseStrategy
+from ..signal_generators import FilteredBlendedMomentumSignalGenerator
+from ..feature import Feature # For type hinting in get_required_features
+
+class FilteredLaggedMomentumStrategy(BaseStrategy):
+    """
+    Implements the momentum strategy based on Calluzzo, Moneta & Topaloglu (2025),
+    featuring dynamic candidate filtering, blended ranking of momentum signals,
+    and a one-month trading lag.
+    """
+
+    signal_generator_class = FilteredBlendedMomentumSignalGenerator
+
+    @classmethod
+    def tunable_parameters(cls) -> set[str]:
+        return {
+            # Parameters for FilteredBlendedMomentumSignalGenerator
+            "momentum_lookback_standard", "momentum_skip_standard",
+            "momentum_lookback_predictive", "momentum_skip_predictive",
+            "blending_lambda",
+            # General strategy parameters
+            "num_holdings", "top_decile_fraction", # top_decile_fraction used by generator
+            "smoothing_lambda", "leverage", "long_only",
+            "sma_filter_window", "derisk_days_under_sma",
+        }
+
+    @classmethod
+    def get_required_features(cls, strategy_config: dict) -> Set[Feature]:
+        """
+        Defines static feature requirements. Relies on BaseStrategy and the
+        configured signal generator to declare most features.
+        """
+        return super().get_required_features(strategy_config)
+
+    def __init__(self, strategy_config: dict):
+        defaults = {
+            "momentum_lookback_standard": 11,
+            "momentum_skip_standard": 1,
+            "momentum_lookback_predictive": 11,
+            "momentum_skip_predictive": 0,
+            "blending_lambda": 0.5,
+            "num_holdings": None,
+            "top_decile_fraction": 0.1,
+            "smoothing_lambda": 0.5,
+            "leverage": 1.0,
+            "long_only": True,
+            "sma_filter_window": None,
+            "derisk_days_under_sma": 10,
+        }
+
+        params_dict_to_update = strategy_config
+        if "strategy_params" in strategy_config:
+            if strategy_config["strategy_params"] is None:
+                 strategy_config["strategy_params"] = {}
+            params_dict_to_update = strategy_config["strategy_params"]
+
+        for k, v in defaults.items():
+            params_dict_to_update.setdefault(k, v)
+
+        self.strategy_config = strategy_config
+        super().__init__(strategy_config)
+
+    def generate_signals(
+        self,
+        prices: pd.DataFrame,
+        features: dict,
+        benchmark_data: pd.Series,
+    ) -> pd.DataFrame:
+        """
+        Generates trading signals using the FilteredBlendedMomentum logic
+        and applies a one-month trading lag to the weights.
+        """
+        weights = super().generate_signals(prices, features, benchmark_data)
+        return weights.shift(1)

--- a/src/portfolio_backtester/strategies/momentum_strategy.py
+++ b/src/portfolio_backtester/strategies/momentum_strategy.py
@@ -1,12 +1,13 @@
 from typing import Set
+import pandas as pd # Keep for general pd use, though not strictly needed by this version
 
 from .base_strategy import BaseStrategy
-from ..signal_generators import MomentumSignalGenerator
+from ..signal_generators import MomentumSignalGenerator # Original generator
 from ..feature import Momentum, BenchmarkSMA, Feature
 
 
 class MomentumStrategy(BaseStrategy):
-    """Momentum strategy implementation."""
+    """Momentum strategy implementation (Original Version)."""
 
     signal_generator_class = MomentumSignalGenerator
 
@@ -15,7 +16,7 @@ class MomentumStrategy(BaseStrategy):
         return {
             "lookback_months", "num_holdings", "top_decile_fraction",
             "smoothing_lambda", "leverage", "long_only", "sma_filter_window",
-            "derisk_days_under_sma",
+            "derisk_days_under_sma", "apply_trading_lag", # Added
         }
 
     @classmethod
@@ -23,13 +24,11 @@ class MomentumStrategy(BaseStrategy):
         # Get the actual strategy parameters, falling back to strategy_config if 'strategy_params' is not present
         params = strategy_config.get("strategy_params", strategy_config)
 
-        # Ensure 'lookback_months' is present in params, otherwise use a default from __init__ or handle error
-        # For now, we assume it's present as per typical scenario structure.
-        # If this method is called with a raw strategy_config (not a full scenario dict),
-        # 'lookback_months' should be directly in it.
         features: Set[Feature] = set()
         lookback = params.get("lookback_months")
         if lookback is not None:
+            # Uses default skip_months=0, name_suffix="".
+            # Name will be "momentum_{lookback}m" due to backward compatibility in Momentum.name
             features.add(Momentum(lookback_months=lookback))
 
         sma_filter = params.get("sma_filter_window")
@@ -37,8 +36,8 @@ class MomentumStrategy(BaseStrategy):
             features.add(BenchmarkSMA(sma_filter_window=sma_filter))
         return features
 
-    def __init__(self, strategy_config):
-        # Ensure all tunable parameters are present in the config with sensible defaults
+    def __init__(self, strategy_config: dict):
+        # Original simple __init__ default handling
         defaults = {
             "lookback_months": 6,
             "num_holdings": None,
@@ -48,8 +47,36 @@ class MomentumStrategy(BaseStrategy):
             "long_only": True,
             "sma_filter_window": None,
             "derisk_days_under_sma": 10,
+            "apply_trading_lag": False, # Added
         }
+
+        # Determine the correct dictionary to apply defaults to
+        # This logic ensures that if strategy_config contains a "strategy_params" sub-dict,
+        # defaults are applied there. Otherwise, they are applied to strategy_config itself.
+        # This is important for how BaseSignalGenerator and BaseStrategy access params.
+        params_dict_to_update = strategy_config
+        if "strategy_params" in strategy_config:
+            if strategy_config["strategy_params"] is None: # Handle case where it's explicitly None
+                 strategy_config["strategy_params"] = {}
+            params_dict_to_update = strategy_config["strategy_params"]
+
         for k, v in defaults.items():
-            strategy_config.setdefault(k, v)
-        self.strategy_config = strategy_config
+            params_dict_to_update.setdefault(k, v)
+
+        self.strategy_config = strategy_config # This is the full config passed to Base class
         super().__init__(strategy_config)
+
+    def generate_signals(
+        self,
+        prices: pd.DataFrame,
+        features: dict,
+        benchmark_data: pd.Series,
+    ) -> pd.DataFrame:
+        """
+        Generates trading signals. Applies a one-month trading lag if configured.
+        """
+        weights = super().generate_signals(prices, features, benchmark_data)
+
+        if self.strategy_config.get("apply_trading_lag", False):
+            return weights.shift(1)
+        return weights

--- a/src/portfolio_backtester/strategies/sharpe_momentum_strategy.py
+++ b/src/portfolio_backtester/strategies/sharpe_momentum_strategy.py
@@ -1,4 +1,5 @@
 from typing import Set
+import pandas as pd # Added
 
 from .base_strategy import BaseStrategy
 from ..signal_generators import SharpeSignalGenerator
@@ -11,4 +12,32 @@ class SharpeMomentumStrategy(BaseStrategy):
 
     @classmethod
     def tunable_parameters(cls) -> set[str]:
-        return {"num_holdings", "rolling_window"}
+        return {"num_holdings", "rolling_window", "apply_trading_lag"} # Added
+
+    def __init__(self, strategy_config: dict):
+        params_dict_to_update = strategy_config
+        if "strategy_params" in strategy_config:
+            if strategy_config["strategy_params"] is None:
+                 strategy_config["strategy_params"] = {}
+            params_dict_to_update = strategy_config["strategy_params"]
+
+        params_dict_to_update.setdefault("apply_trading_lag", False)
+        params_dict_to_update.setdefault("rolling_window", 6) # Default for Sharpe
+
+        self.strategy_config = strategy_config
+        super().__init__(strategy_config)
+
+    def generate_signals(
+        self,
+        prices: pd.DataFrame,
+        features: dict,
+        benchmark_data: pd.Series,
+    ) -> pd.DataFrame:
+        """
+        Generates trading signals. Applies a one-month trading lag if configured.
+        """
+        weights = super().generate_signals(prices, features, benchmark_data)
+
+        if self.strategy_config.get("apply_trading_lag", False):
+            return weights.shift(1)
+        return weights

--- a/src/portfolio_backtester/strategies/sortino_momentum_strategy.py
+++ b/src/portfolio_backtester/strategies/sortino_momentum_strategy.py
@@ -1,4 +1,5 @@
 from typing import Set
+import pandas as pd # Added
 
 from .base_strategy import BaseStrategy
 from ..signal_generators import SortinoSignalGenerator
@@ -11,6 +12,35 @@ class SortinoMomentumStrategy(BaseStrategy):
 
     @classmethod
     def tunable_parameters(cls) -> set[str]:
-        return {"num_holdings", "rolling_window", "sma_filter_window", "target_return"}
+        return {"num_holdings", "rolling_window", "sma_filter_window", "target_return", "apply_trading_lag"} # Added
+
+    def __init__(self, strategy_config: dict):
+        params_dict_to_update = strategy_config
+        if "strategy_params" in strategy_config:
+            if strategy_config["strategy_params"] is None:
+                 strategy_config["strategy_params"] = {}
+            params_dict_to_update = strategy_config["strategy_params"]
+
+        params_dict_to_update.setdefault("apply_trading_lag", False)
+        params_dict_to_update.setdefault("rolling_window", 6) # Default for Sortino
+        params_dict_to_update.setdefault("target_return", 0.0) # Default for Sortino
+
+        self.strategy_config = strategy_config
+        super().__init__(strategy_config)
+
+    def generate_signals(
+        self,
+        prices: pd.DataFrame,
+        features: dict,
+        benchmark_data: pd.Series,
+    ) -> pd.DataFrame:
+        """
+        Generates trading signals. Applies a one-month trading lag if configured.
+        """
+        weights = super().generate_signals(prices, features, benchmark_data)
+
+        if self.strategy_config.get("apply_trading_lag", False):
+            return weights.shift(1)
+        return weights
 
 

--- a/src/portfolio_backtester/strategies/vams_momentum_strategy.py
+++ b/src/portfolio_backtester/strategies/vams_momentum_strategy.py
@@ -1,4 +1,5 @@
 from typing import Set
+import pandas as pd # Added
 
 from .base_strategy import BaseStrategy
 from ..signal_generators import DPVAMSSignalGenerator
@@ -11,6 +12,35 @@ class VAMSMomentumStrategy(BaseStrategy):
 
     @classmethod
     def tunable_parameters(cls) -> set[str]:
-        return {"num_holdings", "lookback_months", "alpha", "sma_filter_window"}
+        return {"num_holdings", "lookback_months", "alpha", "sma_filter_window", "apply_trading_lag"} # Added
+
+    def __init__(self, strategy_config: dict):
+        params_dict_to_update = strategy_config
+        if "strategy_params" in strategy_config:
+            if strategy_config["strategy_params"] is None:
+                 strategy_config["strategy_params"] = {}
+            params_dict_to_update = strategy_config["strategy_params"]
+
+        params_dict_to_update.setdefault("apply_trading_lag", False)
+        params_dict_to_update.setdefault("lookback_months", 6) # Default for VAMS/DPVAMS
+        params_dict_to_update.setdefault("alpha", 0.5) # Default for DPVAMS
+
+        self.strategy_config = strategy_config
+        super().__init__(strategy_config)
+
+    def generate_signals(
+        self,
+        prices: pd.DataFrame,
+        features: dict,
+        benchmark_data: pd.Series,
+    ) -> pd.DataFrame:
+        """
+        Generates trading signals. Applies a one-month trading lag if configured.
+        """
+        weights = super().generate_signals(prices, features, benchmark_data)
+
+        if self.strategy_config.get("apply_trading_lag", False):
+            return weights.shift(1)
+        return weights
 
 

--- a/src/portfolio_backtester/strategies/vams_no_downside_strategy.py
+++ b/src/portfolio_backtester/strategies/vams_no_downside_strategy.py
@@ -1,4 +1,5 @@
 from typing import Set
+import pandas as pd # Added
 
 from .base_strategy import BaseStrategy
 from ..signal_generators import VAMSSignalGenerator
@@ -11,7 +12,35 @@ class VAMSNoDownsideStrategy(BaseStrategy):
 
     @classmethod
     def tunable_parameters(cls) -> set[str]:
-        return {"num_holdings", "lookback_months", "top_decile_fraction", "smoothing_lambda", "leverage", "sma_filter_window"}
+        return {"num_holdings", "lookback_months", "top_decile_fraction", "smoothing_lambda", "leverage", "sma_filter_window", "apply_trading_lag"} # Added
+
+    def __init__(self, strategy_config: dict):
+        params_dict_to_update = strategy_config
+        if "strategy_params" in strategy_config:
+            if strategy_config["strategy_params"] is None:
+                 strategy_config["strategy_params"] = {}
+            params_dict_to_update = strategy_config["strategy_params"]
+
+        params_dict_to_update.setdefault("apply_trading_lag", False)
+        params_dict_to_update.setdefault("lookback_months", 6) # Default for VAMS
+
+        self.strategy_config = strategy_config
+        super().__init__(strategy_config)
+
+    def generate_signals(
+        self,
+        prices: pd.DataFrame,
+        features: dict,
+        benchmark_data: pd.Series,
+    ) -> pd.DataFrame:
+        """
+        Generates trading signals. Applies a one-month trading lag if configured.
+        """
+        weights = super().generate_signals(prices, features, benchmark_data)
+
+        if self.strategy_config.get("apply_trading_lag", False):
+            return weights.shift(1)
+        return weights
 
     
 

--- a/tests/integration/test_integration_backtester.py
+++ b/tests/integration/test_integration_backtester.py
@@ -311,3 +311,113 @@ def cleanup_generated_files_session_scoped(request):
         try:
             if not any(tmp_dir_project.iterdir()): os.rmdir(tmp_dir_project)
         except OSError as e: print(f"Warning: Failed to remove project tmp dir {tmp_dir_project}: {e}")
+
+
+# Programmatic Integration Test for FilteredLaggedMomentumStrategy
+from src.portfolio_backtester.strategies.filtered_lagged_momentum_strategy import FilteredLaggedMomentumStrategy
+from src.portfolio_backtester.config_loader import load_config # load_config might not be needed if config_data is directly used
+from src.portfolio_backtester.feature import Momentum # For generating feature names
+from src.portfolio_backtester.strategies import STRATEGY_REGISTRY
+# NOTE: YFinanceDataSource and FeatureEngine might be heavy for a pure unit test environment.
+# This test assumes they can be instantiated or would be mocked in a more isolated setup.
+# For this integration test, we construct features manually.
+import yaml # For writing temp config
+
+def test_filtered_lagged_momentum_strategy_logic(): # Renamed test
+    # Minimal configuration for FilteredLaggedMomentumStrategy
+    config_data = {
+        "GLOBAL_CONFIG": {
+            "universe": ["AAPL", "MSFT"],
+            "benchmark": "SPY",
+        },
+        "BACKTEST_SCENARIOS": [
+            {
+                "name": "TestFilteredLaggedMomentum",
+                # Use the key that will be added to STRATEGY_REGISTRY for the new strategy
+                "strategy": "filtered_lagged_momentum",
+                "strategy_params": {
+                    "top_decile_fraction": 0.5,
+                    "long_only": True,
+                    "smoothing_lambda": 0.0,
+                    # Using default momentum params from FilteredLaggedMomentumStrategy __init__
+                }
+            }
+        ]
+    }
+    scenario_config = config_data["BACKTEST_SCENARIOS"][0]
+
+    # Ensure the strategy is registered (this test runs after registry update)
+    strategy_class = STRATEGY_REGISTRY.get(scenario_config["strategy"])
+    assert strategy_class is FilteredLaggedMomentumStrategy, \
+        f"Expected FilteredLaggedMomentumStrategy, got {strategy_class}"
+    strategy_instance = strategy_class(scenario_config)
+
+    # Create mock data
+    # Dates for 5 months to observe lag and changes
+    dates_monthly = pd.date_range(start="2022-01-31", periods=5, freq="M")
+    assets = config_data["GLOBAL_CONFIG"]["universe"]
+
+    # Mock feature names based on default strategy params
+    std_mom_params = {"lookback_months": 11, "skip_months": 1, "name_suffix": "std"}
+    pred_mom_params = {"lookback_months": 11, "skip_months": 0, "name_suffix": "pred"}
+    std_mom_name = Momentum(**std_mom_params).name
+    pred_mom_name = Momentum(**pred_mom_params).name
+
+    # Mock feature data: AAPL initially better, then MSFT, then AAPL
+    std_mom_data = pd.DataFrame(0.0, index=dates_monthly, columns=assets)
+    std_mom_data.loc[dates_monthly[0]] = {'AAPL': 0.10, 'MSFT': 0.05} # Jan: AAPL wins
+    std_mom_data.loc[dates_monthly[1]] = {'AAPL': 0.12, 'MSFT': 0.06} # Feb: AAPL wins
+    std_mom_data.loc[dates_monthly[2]] = {'AAPL': 0.08, 'MSFT': 0.10} # Mar: MSFT wins
+    std_mom_data.loc[dates_monthly[3]] = {'AAPL': 0.11, 'MSFT': 0.07} # Apr: AAPL wins
+    # Let predictive momentum confirm standard momentum for simplicity of checking survivors
+    pred_mom_data = std_mom_data.copy()
+
+    mock_features_for_strategy = { std_mom_name: std_mom_data, pred_mom_name: pred_mom_data }
+
+    # Mock prices (only index and columns matter for generate_signals if scores are provided)
+    # However, BaseStrategy's derisk logic might use actual price/benchmark relationship.
+    # Let's make sma_filter_window null in strategy_params to disable derisking for this test.
+    strategy_instance.strategy_config.get("strategy_params", strategy_instance.strategy_config)["sma_filter_window"] = None
+
+
+    mock_prices_monthly = pd.DataFrame(100.0, index=dates_monthly, columns=assets)
+    mock_benchmark_monthly = pd.Series(100.0, index=dates_monthly, name="SPY")
+
+    generated_weights_df = strategy_instance.generate_signals(
+        mock_prices_monthly,
+        mock_features_for_strategy,
+        mock_benchmark_monthly
+    )
+
+    # 1. Test lag: First row of weights should be all NaN due to .shift(1)
+    assert generated_weights_df.iloc[0].isnull().all(), \
+        "First row of weights should be NaN due to shift(1) trading lag."
+
+    # 2. Test weights based on (lagged) signals
+    # generated_weights_df.loc[T] uses original_scores.loc[T-1]
+    # Original scores are blended ranks. With lambda=0.5, and pred=std, blended rank = std_rank.
+    # top_decile_fraction=0.5 means 1 asset out of 2 is chosen.
+    # Winner gets rank 1.0 (if only one survivor in its class) or based on pct_rank.
+    # With 2 assets, top 1 winner: rank 1.0. Loser: rank 0.0 (if only long)
+    # If long_only=True, only positive scores matter for _calculate_candidate_weights.
+    # The blended scores are ranks (0-1). BaseStrategy._calculate_candidate_weights picks nlargest.
+
+    # For Jan scores (AAPL=0.10, MSFT=0.05): AAPL is winner. Expected blended score for AAPL is 1.0.
+    # This applies to generated_weights_df.loc[dates_monthly[1]] (Feb end)
+    assert abs(generated_weights_df.loc[dates_monthly[1], 'AAPL'] - 1.0) < 1e-6
+    assert abs(generated_weights_df.loc[dates_monthly[1], 'MSFT'] - 0.0) < 1e-6
+
+    # For Feb scores (AAPL=0.12, MSFT=0.06): AAPL is winner.
+    # This applies to generated_weights_df.loc[dates_monthly[2]] (Mar end)
+    assert abs(generated_weights_df.loc[dates_monthly[2], 'AAPL'] - 1.0) < 1e-6
+    assert abs(generated_weights_df.loc[dates_monthly[2], 'MSFT'] - 0.0) < 1e-6
+
+    # For Mar scores (AAPL=0.08, MSFT=0.10): MSFT is winner.
+    # This applies to generated_weights_df.loc[dates_monthly[3]] (Apr end)
+    assert abs(generated_weights_df.loc[dates_monthly[3], 'MSFT'] - 1.0) < 1e-6
+    assert abs(generated_weights_df.loc[dates_monthly[3], 'AAPL'] - 0.0) < 1e-6
+
+    # For Apr scores (AAPL=0.11, MSFT=0.07): AAPL is winner
+    # This applies to generated_weights_df.loc[dates_monthly[4]] (May end)
+    assert abs(generated_weights_df.loc[dates_monthly[4], 'AAPL'] - 1.0) < 1e-6
+    assert abs(generated_weights_df.loc[dates_monthly[4], 'MSFT'] - 0.0) < 1e-6

--- a/tests/integration/test_strategy_lag_config.py
+++ b/tests/integration/test_strategy_lag_config.py
@@ -1,0 +1,83 @@
+import pytest
+import pandas as pd
+import numpy as np
+
+from src.portfolio_backtester.strategies import (
+    MomentumStrategy,
+    CalmarMomentumStrategy,
+    SharpeMomentumStrategy,
+    SortinoMomentumStrategy,
+    VAMSMomentumStrategy,
+    VAMSNoDownsideStrategy,
+    MomentumDvolSizerStrategy
+)
+from src.portfolio_backtester.feature import Momentum # For feature name generation
+
+strategies_to_test_lag = [
+    (MomentumStrategy, {"lookback_months": 6}),
+    (CalmarMomentumStrategy, {"rolling_window": 6}),
+    (SharpeMomentumStrategy, {"rolling_window": 6}),
+    (SortinoMomentumStrategy, {"rolling_window": 6, "target_return": 0.0}),
+    (VAMSMomentumStrategy, {"lookback_months": 6, "alpha": 0.5}), # Uses DPVAMSSignalGenerator
+    (VAMSNoDownsideStrategy, {"lookback_months": 6}), # Uses VAMSSignalGenerator
+    (MomentumDvolSizerStrategy, {"lookback_months": 6}),
+]
+
+@pytest.mark.parametrize("strategy_class, initial_params", strategies_to_test_lag)
+def test_configurable_trading_lag(strategy_class, initial_params):
+    dates = pd.date_range(start="2023-01-31", periods=3, freq="M")
+    assets = ["AssetX", "AssetY"]
+
+    mock_prices = pd.DataFrame(100.0, index=dates, columns=assets)
+    mock_benchmark = pd.Series(100.0, index=dates, name="BENCH")
+
+    mock_features = {}
+    # Construct expected feature names based on strategy and its default generator params
+    if strategy_class in [MomentumStrategy, MomentumDvolSizerStrategy]:
+        lb = initial_params.get("lookback_months", 6)
+        # Momentum feature with skip=0, no_suffix has name "momentum_{lb}m"
+        mock_features[Momentum(lookback_months=lb).name] = pd.DataFrame(0.1, index=dates, columns=assets)
+    elif strategy_class == CalmarMomentumStrategy:
+        rw = initial_params.get("rolling_window", 6)
+        mock_features[f"calmar_{rw}m"] = pd.DataFrame(0.1, index=dates, columns=assets)
+    elif strategy_class == SharpeMomentumStrategy:
+        rw = initial_params.get("rolling_window", 6)
+        mock_features[f"sharpe_{rw}m"] = pd.DataFrame(0.1, index=dates, columns=assets)
+    elif strategy_class == SortinoMomentumStrategy:
+        rw = initial_params.get("rolling_window", 6)
+        mock_features[f"sortino_{rw}m"] = pd.DataFrame(0.1, index=dates, columns=assets)
+    elif strategy_class == VAMSMomentumStrategy: # DPVAMS
+        lb = initial_params.get("lookback_months", 6)
+        alpha = initial_params.get("alpha", 0.5)
+        mock_features[f"dp_vams_{lb}m_{alpha:.2f}a"] = pd.DataFrame(0.1, index=dates, columns=assets)
+    elif strategy_class == VAMSNoDownsideStrategy: # VAMS
+        lb = initial_params.get("lookback_months", 6)
+        mock_features[f"vams_{lb}m"] = pd.DataFrame(0.1, index=dates, columns=assets)
+
+    # Config for lag=True
+    # Ensure 'strategy_params' exists and is a dict for setdefault
+    config_lag_true_dict = {"strategy_params": {**initial_params, "apply_trading_lag": True, "sma_filter_window": None}}
+    strategy_lag_true = strategy_class(config_lag_true_dict)
+    weights_lag_true = strategy_lag_true.generate_signals(mock_prices, mock_features, mock_benchmark)
+
+    assert weights_lag_true.iloc[0].isnull().all(), \
+        f"{strategy_class.__name__} with apply_trading_lag=True should have NaNs in the first row."
+    if len(weights_lag_true) > 1 :
+      assert not weights_lag_true.iloc[1:].isnull().values.all(), \
+          f"{strategy_class.__name__} with apply_trading_lag=True should have some non-NaNs after first row for this mock data (unless all signals were zero)."
+
+    # Config for lag=False
+    config_lag_false_dict = {"strategy_params": {**initial_params, "apply_trading_lag": False, "sma_filter_window": None}}
+    strategy_lag_false = strategy_class(config_lag_false_dict)
+    weights_lag_false = strategy_lag_false.generate_signals(mock_prices, mock_features, mock_benchmark)
+
+    # Check that the first row is NOT all NaNs (it should have some values)
+    # This depends on BaseStrategy not producing all zeros/NaNs for the first period with these simple inputs.
+    # Given a constant signal of 0.1, it should produce some weights.
+    assert not weights_lag_false.iloc[0].isnull().values.all(), \
+        f"{strategy_class.__name__} with apply_trading_lag=False should not have all NaNs in the first row."
+    # A more robust check might be that it's not *all* NaN, rather than *no* NaNs.
+    # If all signals were NaN, then even without lag, first row could be NaN.
+    # But with constant 0.1 signals, it should produce weights.
+    assert weights_lag_false.iloc[0].notnull().values.any(), \
+        f"{strategy_class.__name__} with apply_trading_lag=False should have at least some non-NaNs in the first row."

--- a/tests/unit/test_features.py
+++ b/tests/unit/test_features.py
@@ -1,0 +1,64 @@
+import pytest
+import pandas as pd
+import numpy as np
+from src.portfolio_backtester.feature import Momentum
+
+class TestMomentumFeature:
+    @pytest.fixture
+    def sample_monthly_prices(self) -> pd.DataFrame:
+        dates = pd.date_range(start='2020-01-31', periods=24, freq='M') # Use month-end dates
+        data = {
+            'AssetA': np.linspace(100, 100 + 23 * 2, 24),
+            'AssetB': np.concatenate([np.linspace(100, 120, 12), np.linspace(119, 100, 12)]),
+            'AssetC': np.concatenate([np.full(12, 100.0), np.linspace(100.0, 100.0 + 11 * 2, 12)]) # Start flat part at 100
+        }
+        # Ensure float type for prices
+        df = pd.DataFrame(data, index=dates).astype(float)
+        return df
+
+    def test_momentum_no_skip(self, sample_monthly_prices):
+        feature = Momentum(lookback_months=3, skip_months=0)
+        mom_values = feature.compute(sample_monthly_prices)
+
+        # Expected for AssetA at 2020-03-31 (index 2): P(Mar)/P(Jan)-1, since ret_Jan is 0 due to fillna(0)
+        # P_Jan = 100, P_Mar = 104 for AssetA
+        expected_asset_a_mar = (sample_monthly_prices.loc['2020-03-31', 'AssetA'] /
+                                sample_monthly_prices.loc['2020-01-31', 'AssetA']) - 1
+        assert abs(mom_values.loc['2020-03-31', 'AssetA'] - expected_asset_a_mar) < 1e-6
+
+        # Expected for AssetA at 2020-04-30 (index 3): P(Apr)/P(Feb)-1
+        # P_Feb = 102, P_Apr = 106 for AssetA
+        expected_asset_a_apr = (sample_monthly_prices.loc['2020-04-30', 'AssetA'] /
+                                sample_monthly_prices.loc['2020-02-29', 'AssetA']) - 1
+        assert abs(mom_values.loc['2020-04-30', 'AssetA'] - expected_asset_a_apr) < 1e-6
+
+
+    def test_momentum_with_skip(self, sample_monthly_prices):
+        feature = Momentum(lookback_months=3, skip_months=1)
+        mom_values = feature.compute(sample_monthly_prices)
+
+        # For L=3, S=1, value at date 't' is based on P(t-1)/P(t-1-3) = P(t-1)/P(t-4)
+        # First valid point for mom_values will be 2020-04-30 (index 3)
+        # This uses momentum_lookback_period.loc['2020-03-31']
+        # momentum_lookback_period.loc['2020-03-31'] is P(Mar)/P(Jan)-1 for AssetA = 104/100-1 = 0.04
+        expected_val_apr = (sample_monthly_prices.loc['2020-03-31', 'AssetA'] /
+                            sample_monthly_prices.loc['2020-01-31', 'AssetA']) - 1
+        assert abs(mom_values.loc['2020-04-30', 'AssetA'] - expected_val_apr) < 1e-6
+
+        # Check AssetA at 2020-05-31 (index 4)
+        # This uses momentum_lookback_period.loc['2020-04-30']
+        # momentum_lookback_period.loc['2020-04-30'] is P(Apr)/P(Feb)-1 for AssetA = 106/102-1
+        expected_val_may = (sample_monthly_prices.loc['2020-04-30', 'AssetA'] /
+                            sample_monthly_prices.loc['2020-02-29', 'AssetA']) - 1
+        assert abs(mom_values.loc['2020-05-31', 'AssetA'] - expected_val_may) < 1e-6
+
+
+    def test_momentum_name_generation(self):
+        f1 = Momentum(12, 0)
+        assert f1.name == "momentum_12m_skip0m"
+        f2 = Momentum(6, 1, name_suffix="std")
+        assert f2.name == "momentum_6m_skip1m_std"
+        f3 = Momentum(3, name_suffix="pred_mom") # skip default 0
+        assert f3.name == "momentum_3m_skip0m_pred_mom"
+        f4 = Momentum(lookback_months=5) # skip=0, suffix=""
+        assert f4.name == "momentum_5m_skip0m"


### PR DESCRIPTION
- Refactored `get_required_features_from_scenarios` in `feature.py` to correctly identify and generate all combinations of optimizable parameters for the new `FilteredLaggedMomentumStrategy` (momentum_lookback_standard, momentum_skip_standard, momentum_lookback_predictive, momentum_skip_predictive). This resolves KeyErrors during optimization where specific feature variations were not pre-computed.
- Improved the helper function `_get_opt_values_for_param` for more robustly determining parameter value ranges during optimization sweeps.
- This also standardizes feature collection for other optimizable parameters like `sma_filter_window`, `lookback_months`, `alpha`, and `rolling_window`.

This commit also includes the prior work from the session:
- Reverted MomentumStrategy to its original state.
- Created FilteredLaggedMomentumStrategy with Calluzzo et al. methodology.
- Added configurable 'apply_trading_lag' to relevant strategies.
- Updated config/parameters.yaml for new optimizable parameters.
- Added and updated unit and integration tests for all changes.